### PR TITLE
Ensure exactly one argument to get command

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -13,6 +13,7 @@ type dynamicValue = interface{}
 var getCmd = &cobra.Command{
 	Use:   "get [variable]",
 	Short: "Get a variable value",
+	Args:  cobra.ExactArgs(1),
 	//Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		context := getProjectContext()


### PR DESCRIPTION
Running `get` without arguments results in a panic

```
$ shuttle get
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/lunarway/shuttle/cmd.glob..func3(0x148ce00, 0x14b0878, 0x0, 0x0)
	/home/travis/gopath/src/github.com/lunarway/shuttle/cmd/get.go:21 +0xea
github.com/spf13/cobra.(*Command).execute(0x148ce00, 0x14b0878, 0x0, 0x0, 0x148ce00, 0x14b0878)
	/home/travis/gopath/src/github.com/spf13/cobra/command.go:766 +0x2c1
github.com/spf13/cobra.(*Command).ExecuteC(0x148c940, 0x13077ec, 0x26, 0x148c6e0)
	/home/travis/gopath/src/github.com/spf13/cobra/command.go:852 +0x30a
github.com/spf13/cobra.(*Command).Execute(0x148c940, 0x1003a8c, 0xc42008a058)
	/home/travis/gopath/src/github.com/spf13/cobra/command.go:800 +0x2b
github.com/lunarway/shuttle/cmd.Execute()
	/home/travis/gopath/src/github.com/lunarway/shuttle/cmd/root.go:44 +0x31
main.main()
	/home/travis/gopath/src/github.com/lunarway/shuttle/main.go:8 +0x20
```

This fix ensures exactly one argument is provided.