### PR TITLE
Ensure to not format output that don't need it

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,10 +38,10 @@ Read more about shuttle at https://github.com/lunarway/shuttle`, version),
 			uii = uii.SetUserLevel(ui.LevelVerbose)
 		}
 
-		uii.VerboseLn("Running shuttle")
-		uii.VerboseLn("- version: %s", version)
-		uii.VerboseLn("- commit: %s", commit)
-		uii.VerboseLn("- project-path: %s", projectPath)
+		uii.Verboseln("Running shuttle")
+		uii.Verboseln("- version: %s", version)
+		uii.Verboseln("- commit: %s", commit)
+		uii.Verboseln("- project-path: %s", projectPath)
 	},
 }
 

--- a/pkg/config/shuttleconfig.go
+++ b/pkg/config/shuttleconfig.go
@@ -42,7 +42,7 @@ func (c *ShuttleProjectContext) Setup(projectPath string, uii ui.UI, clean bool,
 
 	if clean {
 		os.RemoveAll(c.LocalShuttleDirectoryPath)
-		uii.InfoLn("Cleaning %s", c.LocalShuttleDirectoryPath)
+		uii.Infoln("Cleaning %s", c.LocalShuttleDirectoryPath)
 	}
 	os.MkdirAll(c.LocalShuttleDirectoryPath, os.ModePerm)
 

--- a/pkg/config/shuttleplan.go
+++ b/pkg/config/shuttleplan.go
@@ -69,18 +69,18 @@ func (p *ShuttlePlanConfiguration) Load(planPath string) *ShuttlePlanConfigurati
 func FetchPlan(plan string, projectPath string, localShuttleDirectoryPath string, uii ui.UI, skipGitPlanPulling bool) string {
 	switch {
 	case plan == "":
-		uii.VerboseLn("Using no plan")
+		uii.Verboseln("Using no plan")
 		return ""
 	case git.IsGitPlan(plan):
-		uii.VerboseLn("Using git plan at '%s'", plan)
+		uii.Verboseln("Using git plan at '%s'", plan)
 		return git.GetGitPlan(plan, localShuttleDirectoryPath, uii, skipGitPlanPulling)
 	case isMatching("^http://|^https://", plan):
 		panic("plan not valid: http is not supported yet")
 	case isFilePath(plan, true):
-		uii.VerboseLn("Using local plan at '%s'", plan)
+		uii.Verboseln("Using local plan at '%s'", plan)
 		return plan
 	case isFilePath(plan, false):
-		uii.VerboseLn("Using local plan at '%s'", plan)
+		uii.Verboseln("Using local plan at '%s'", plan)
 		return path.Join(projectPath, plan)
 
 	}

--- a/pkg/executors/shell.go
+++ b/pkg/executors/shell.go
@@ -42,15 +42,15 @@ func executeShell(context ActionExecutionContext) {
 		for {
 			select {
 			case line := <-execCmd.Stdout:
-				context.ScriptContext.Project.UI.InfoLn(line)
+				context.ScriptContext.Project.UI.Infoln("%s", line)
 			case line := <-execCmd.Stderr:
-				context.ScriptContext.Project.UI.ErrorLn(line)
+				context.ScriptContext.Project.UI.Errorln("%s", line)
 			}
 		}
 	}()
 
 	// Run and wait for Cmd to return, discard Status
-	context.ScriptContext.Project.UI.TitleLn("shell: %s", context.Action.Shell)
+	context.ScriptContext.Project.UI.Titleln("shell: %s", context.Action.Shell)
 	status := <-execCmd.Start()
 
 	// Cmd has finished but wait for goroutine to print all lines

--- a/pkg/git/main.go
+++ b/pkg/git/main.go
@@ -71,7 +71,7 @@ func GetGitPlan(plan string, localShuttleDirectoryPath string, uii ui.UI, skipGi
 	plansAlreadyValidated := strings.Split(os.Getenv("SHUTTLE_PLANS_ALREADY_VALIDATED"), string(os.PathListSeparator))
 	for _, planAlreadyValidated := range plansAlreadyValidated {
 		if planAlreadyValidated == planPath {
-			uii.VerboseLn("Shuttle already validated plan. Skipping further plan validation")
+			uii.Verboseln("Shuttle already validated plan. Skipping further plan validation")
 			return planPath
 		}
 	}
@@ -82,16 +82,16 @@ func GetGitPlan(plan string, localShuttleDirectoryPath string, uii ui.UI, skipGi
 		if status.mergeState {
 			uii.ExitWithErrorCode(9, "Plan's cloned output is in merge state. Please resolve merge conflicts and the try again")
 		} else if status.changes {
-			uii.EmphasizeInfoLn("Found %v files locally changed in plan", len(status.files))
-			uii.EmphasizeInfoLn("Skipping plan pull because of changes")
+			uii.EmphasizeInfoln("Found %v files locally changed in plan", len(status.files))
+			uii.EmphasizeInfoln("Skipping plan pull because of changes")
 		} else {
 			if skipGitPlanPulling {
-				uii.VerboseLn("Skipping git plan pulling")
+				uii.Verboseln("Skipping git plan pulling")
 				return planPath
 			}
 
-			uii.InfoLn("Pulling latest plan changes")
-			uii.VerboseLn("Using %s - branch %s - commit %s", plan, status.branch, status.commit)
+			uii.Infoln("Pulling latest plan changes")
+			uii.Verboseln("Using %s - branch %s - commit %s", plan, status.branch, status.commit)
 			gitCmd("pull origin", planPath, uii)
 		}
 		return planPath
@@ -107,7 +107,7 @@ func GetGitPlan(plan string, localShuttleDirectoryPath string, uii ui.UI, skipGi
 			panic(fmt.Sprintf("Unknown protocol '%s'", parsedGitPlan.protocol))
 		}
 
-		uii.InfoLn("Cloning plan %s", cloneArg)
+		uii.Infoln("Cloning plan %s", cloneArg)
 		gitCmd("clone "+cloneArg+" plan", localShuttleDirectoryPath, uii)
 	}
 
@@ -124,9 +124,9 @@ func RunGitPlanCommand(command string, plan string, uii ui.UI) {
 		for {
 			select {
 			case line := <-execCmd.Stdout:
-				uii.InfoLn(line)
+				uii.Infoln("%s", line)
 			case line := <-execCmd.Stderr:
-				uii.InfoLn(line)
+				uii.Infoln("%s", line)
 			}
 		}
 	}()
@@ -179,9 +179,9 @@ func gitCmd(command string, dir string, uii ui.UI) {
 		for {
 			select {
 			case line := <-execCmd.Stdout:
-				uii.VerboseLn("git> " + line)
+				uii.Verboseln("git> %s", line)
 			case line := <-execCmd.Stderr:
-				uii.VerboseLn("git> " + line)
+				uii.Verboseln("git> %s", line)
 			}
 		}
 	}()

--- a/pkg/ui/main.go
+++ b/pkg/ui/main.go
@@ -49,47 +49,46 @@ func (ui *UI) SetContext(level Level) UI {
 	}
 }
 
-// VerboseLn doc
-func (ui *UI) VerboseLn(msg string, args ...interface{}) {
+// Verboseln prints a formatted verbose message line.
+func (ui *UI) Verboseln(format string, args ...interface{}) {
 	if ui.EffectiveLevel.OutputIsIncluded(LevelVerbose) {
-		fmt.Println(fmt.Sprintf(msg, args...))
+		fmt.Println(fmt.Sprintf(format, args...))
 	}
 }
 
-// InfoLn doc
-func (ui *UI) InfoLn(msg string, args ...interface{}) {
+// Infoln prints a formatted info message line.
+func (ui *UI) Infoln(format string, args ...interface{}) {
 	if ui.EffectiveLevel.OutputIsIncluded(LevelInfo) {
-		fmt.Println(fmt.Sprintf(msg, args...))
+		fmt.Println(fmt.Sprintf(format, args...))
 	}
 }
 
-// EmphasizeInfoLn doc
-func (ui *UI) EmphasizeInfoLn(msg string, args ...interface{}) {
+func (ui *UI) EmphasizeInfoln(format string, args ...interface{}) {
 	if ui.EffectiveLevel.OutputIsIncluded(LevelInfo) {
-		ui.InfoLn("\x1b[032;1m"+msg+"\x1b[0m", args...)
+		fmt.Printf("\x1b[032;1m%s\x1b[0m\n", fmt.Sprintf(format, args...))
 	}
 }
 
-// TitleLn doc
-func (ui *UI) TitleLn(msg string, args ...interface{}) {
-	ui.InfoLn("\x1b[1m"+msg+"\x1b[0m", args...)
+// Titleln doc
+func (ui *UI) Titleln(format string, args ...interface{}) {
+	ui.Infoln("\x1b[1m%s\x1b[0m", fmt.Sprintf(format, args...))
 }
 
-// ErrorLn doc
-func (ui *UI) ErrorLn(msg string, args ...interface{}) {
+// Errorln doc
+func (ui *UI) Errorln(format string, args ...interface{}) {
 	if ui.EffectiveLevel.OutputIsIncluded(LevelInfo) {
-		fmt.Fprintln(os.Stderr, fmt.Sprintf("\x1b[31;1m"+msg+"\x1b[0m", args...))
+		fmt.Fprintf(os.Stderr, "\x1b[31;1m%s\x1b[0m\n", fmt.Sprintf(format, args...))
 	}
 }
 
 // ExitWithError doc
-func (ui *UI) ExitWithError(msg string, args ...interface{}) {
-	ui.ExitWithErrorCode(1, msg, args...)
+func (ui *UI) ExitWithError(format string, args ...interface{}) {
+	ui.ExitWithErrorCode(1, format, args...)
 }
 
 // ExitWithErrorCode doc
-func (ui *UI) ExitWithErrorCode(code int, msg string, args ...interface{}) {
-	ui.ErrorLn("shuttle failed\n"+msg, args...)
+func (ui *UI) ExitWithErrorCode(code int, format string, args ...interface{}) {
+	ui.Errorln("shuttle failed\n"+format, args...)
 	os.Exit(code)
 }
 
@@ -98,5 +97,5 @@ func (ui *UI) CheckIfError(err error) {
 	if err == nil {
 		return
 	}
-	ui.ExitWithError(fmt.Sprintf("error: %s", err))
+	ui.ExitWithError("error: %s", err)
 }


### PR DESCRIPTION
This change renames line output functions to follow Go conventions of lower casing `ln`, eg. `VerboseLn` -> `Verboseln`.

Further does it handle message formating so percentage signs are not formatted if they are not intended to (closes #18)