### PR TITLE
Log the script failing in shell executor

### DIFF
--- a/examples/station-plan/plan.yaml
+++ b/examples/station-plan/plan.yaml
@@ -21,3 +21,10 @@ scripts:
     args: []
     actions:
     - shell: exit 1
+  required-arg:
+    description: Provide arg and succeed
+    args:
+    - name: a
+      required: true
+    actions:
+    - shell: echo "Arg provided"

--- a/pkg/executors/executor.go
+++ b/pkg/executors/executor.go
@@ -39,7 +39,7 @@ func Execute(p config.ShuttleProjectContext, command string, args []string) {
 
 	for _, argSpec := range script.Args {
 		if _, ok := namedArgs[argSpec.Name]; argSpec.Required && !ok {
-			p.UI.ExitWithError("Required argument `%s` was not supplied!", argSpec.Name) // TODO: Add expected arguments
+			p.UI.ExitWithError("Required argument `%s` for script `%s` was not supplied!", argSpec.Name, command) // TODO: Add expected arguments
 		}
 	}
 

--- a/pkg/executors/shell.go
+++ b/pkg/executors/shell.go
@@ -59,7 +59,7 @@ func executeShell(context ActionExecutionContext) {
 	}
 
 	if status.Exit > 0 {
-		context.ScriptContext.Project.UI.ExitWithErrorCode(4, "Failed executing shell script `%s`\nExit code: %v", context.Action.Shell, status.Exit)
+		context.ScriptContext.Project.UI.ExitWithErrorCode(4, "Failed executing script '%s': shell script `%s`\nExit code: %v", context.ScriptContext.ScriptName, context.Action.Shell, status.Exit)
 	}
 }
 

--- a/pkg/executors/shell.go
+++ b/pkg/executors/shell.go
@@ -59,7 +59,7 @@ func executeShell(context ActionExecutionContext) {
 	}
 
 	if status.Exit > 0 {
-		context.ScriptContext.Project.UI.ExitWithErrorCode(4, "Failed executing script '%s': shell script `%s`\nExit code: %v", context.ScriptContext.ScriptName, context.Action.Shell, status.Exit)
+		context.ScriptContext.Project.UI.ExitWithErrorCode(4, "Failed executing script `%s`: shell script `%s`\nExit code: %v", context.ScriptContext.ScriptName, context.Action.Shell, status.Exit)
 	}
 }
 

--- a/tests.sh
+++ b/tests.sh
@@ -107,5 +107,12 @@ test_run_shell_error_outputs_script_name() {
   fi
 }
 
+test_run_shell_error_outputs_missing_arg() {
+  assertErrorCode 1 -p examples/moon-base run required-arg
+  if [[ ! "$result" =~ "required-arg" ]]; then
+    fail "Expected output to contain the script name 'required-arg', but it was:\n$result"
+  fi
+}
+
 # Load and run shUnit2.
 . ./shunit2

--- a/tests.sh
+++ b/tests.sh
@@ -100,5 +100,12 @@ test_run_shell_error_outputs_exit_code() {
   fi
 }
 
+test_run_shell_error_outputs_script_name() {
+  assertErrorCode 4 -p examples/moon-base run crash
+  if [[ ! "$result" =~ "crash" ]]; then
+    fail "Expected output to contain the script name 'crash', but it was:\n$result"
+  fi
+}
+
 # Load and run shUnit2.
 . ./shunit2


### PR DESCRIPTION
When running multiple or nested plan scripts, the error log does not provide any details of what script failed.

This change adds the failling script name to the error log.

```
$ go run main.go --project examples/moon-base run say-hi && go run main.go --project examples/moon-base run crash
shell: echo "test"
test
shell: exit 1
shuttle failed
Failed executing script 'crash': shell script `exit 1`
Exit code: 1
```

Closes #26