### PR TITLE
Handle missing and invalid shuttle configuration gracefully

### DIFF
--- a/examples/bad/yaml-invalid/shuttle.yaml
+++ b/examples/bad/yaml-invalid/shuttle.yaml
@@ -1,0 +1,3 @@
+&aplan: '../../station-plan'
+vars:
+  23.1

--- a/pkg/config/shuttleconfig.go
+++ b/pkg/config/shuttleconfig.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -35,7 +34,7 @@ type ShuttleProjectContext struct {
 
 // Setup the ShuttleProjectContext for a specific path
 func (c *ShuttleProjectContext) Setup(projectPath string, uii ui.UI, clean bool, skipGitPlanPulling bool) *ShuttleProjectContext {
-	c.Config.getConf(projectPath)
+	c.Config.getConf(uii, projectPath)
 	c.UI = uii
 	c.ProjectPath = projectPath
 	c.LocalShuttleDirectoryPath = path.Join(c.ProjectPath, ".shuttle")
@@ -60,18 +59,18 @@ func (c *ShuttleProjectContext) Setup(projectPath string, uii ui.UI, clean bool,
 }
 
 // getConf loads the ShuttleConfig from yaml file in the project path
-func (c *ShuttleConfig) getConf(projectPath string) *ShuttleConfig {
+func (c *ShuttleConfig) getConf(uii ui.UI, projectPath string) *ShuttleConfig {
 	var configPath = path.Join(projectPath, "shuttle.yaml")
 
 	//log.Printf("configpath: %s", configPath)
 
 	yamlFile, err := ioutil.ReadFile(configPath)
 	if err != nil {
-		panic(fmt.Sprintf("yamlFile.Get err   #%v ", err))
+		uii.ExitWithErrorCode(2, "Failed to load shuttle configuration: %s\n\nMake sure you are in a project using shuttle and that a 'shuttle.yaml' file is available.", err)
 	}
 	err = yaml.Unmarshal(yamlFile, c)
 	if err != nil {
-		panic(fmt.Sprintf("Unmarshal: %v", err))
+		uii.ExitWithErrorCode(2, "Failed to parse shuttle configuration: %s\n\nMake sure your 'shuttle.yaml' is valid.", err)
 	}
 
 	switch c.PlanRaw {

--- a/tests.sh
+++ b/tests.sh
@@ -20,6 +20,14 @@ function assertErrorCode() {
   fi
 }
 
+function assertContains() {
+  local expectedResult=$1
+  local actualResult=$2
+  if [[ ! "$actualResult" =~ "$expectedResult" ]]; then
+    fail "Expected output to contain '$expectedResult', but it was:\n$actualResult"
+  fi
+}
+
 test_moon_base_builds() {
   assertRun -p examples/moon-base run build tag=test
 }
@@ -30,6 +38,7 @@ test_moon_base_builds_with_absolute_path() {
 
 test_venus_base_fails() {
   assertErrorCode 2 -p examples/venus-base run build tag=test
+  assertContains "Failed to load shuttle configuration" "$result"
 }
 
 test_can_get_variable_from_local_plan() {
@@ -44,9 +53,12 @@ test_can_get_variable_from_repo_plan() {
 
 test_fails_getting_no_repo_plan() {
   assertErrorCode 4 -p examples/bad/no-repo-project ls
-  if [[ ! "$result" =~ "Failed executing git command \`clone" ]]; then
-    fail "Expected output to contain 'Failed executing git command \`clone', but it was:\n$result"
-  fi
+  assertContains "Failed executing git command \`clone" "$result"
+}
+
+test_fails_loading_invalid_shuttle_configuration() {
+  assertErrorCode 2 -p examples/bad/yaml-invalid ls
+  assertContains "Failed to parse shuttle configuration" "$result"
 }
 
 test_get_a_boolean() {
@@ -95,9 +107,7 @@ test_can_execute_shuttle_version_without_error() {
 
 test_run_shell_error_outputs_exit_code() {
   assertErrorCode 4 -p examples/moon-base run crash
-  if [[ ! "$result" =~ "Exit code: 1" ]]; then
-    fail "Expected output to contain 'Exit code: 1', but it was:\n$result"
-  fi
+  assertContains "Exit code: 1" "$result"
 }
 
 test_run_shell_error_outputs_script_name() {


### PR DESCRIPTION
The current implementation panics and logs a stack trace along with a rather hard to read error message.

```
$ shuttle -p examples ls
panic: yamlFile.Get err   #open /Users/bjornsorensen/gitRepo/shuttle/examples/shuttle.yaml: no such file or directory

goroutine 1 [running]:
github.com/lunarway/shuttle/pkg/config.(*ShuttleConfig).getConf(0xc0000ce270, 0xc00001a5a0, 0x2d, 0x0)
	/home/travis/gopath/src/github.com/lunarway/shuttle/pkg/config/shuttleconfig.go:70 +0x2ad
github.com/lunarway/shuttle/pkg/config.(*ShuttleProjectContext).Setup(0xc0000ce240, 0xc00001a5a0, 0x2d, 0x132391c, 0x4, 0x132391c, 0x4, 0x0, 0x0, 0x0, ...)
	/home/travis/gopath/src/github.com/lunarway/shuttle/pkg/config/shuttleconfig.go:38 +0x63
github.com/lunarway/shuttle/cmd.getProjectContext(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/travis/gopath/src/github.com/lunarway/shuttle/cmd/root.go:77 +0x197
github.com/lunarway/shuttle/cmd.glob..func6(0x15659e0, 0xc00000a7c0, 0x0, 0x2)
	/home/travis/gopath/src/github.com/lunarway/shuttle/cmd/ls.go:26 +0x37
github.com/spf13/cobra.(*Command).execute(0x15659e0, 0xc00000a760, 0x2, 0x2, 0x15659e0, 0xc00000a760)
	/home/travis/gopath/src/github.com/spf13/cobra/command.go:766 +0x2cc
github.com/spf13/cobra.(*Command).ExecuteC(0x15665c0, 0x8, 0x9, 0xc0000bc380)
	/home/travis/gopath/src/github.com/spf13/cobra/command.go:852 +0x2fd
github.com/spf13/cobra.(*Command).Execute(0x15665c0, 0x1566360, 0xc0000dbf20)
	/home/travis/gopath/src/github.com/spf13/cobra/command.go:800 +0x2b
github.com/lunarway/shuttle/cmd.Execute()
	/home/travis/gopath/src/github.com/lunarway/shuttle/cmd/root.go:49 +0x3f
main.main()
	/home/travis/gopath/src/github.com/lunarway/shuttle/main.go:8 +0x20

$ shuttle -p examples/bad/yaml-invalid ls
panic: Unmarshal: yaml: unmarshal errors:
  line 3: cannot unmarshal !!float `23.1` into map[string]interface {}

goroutine 1 [running]:
github.com/lunarway/shuttle/pkg/config.(*ShuttleConfig).getConf(0xc0000ce270, 0xc000012540, 0x3e, 0x0)
	/home/travis/gopath/src/github.com/lunarway/shuttle/pkg/config/shuttleconfig.go:74 +0x21e
github.com/lunarway/shuttle/pkg/config.(*ShuttleProjectContext).Setup(0xc0000ce240, 0xc000012540, 0x3e, 0x132391c, 0x4, 0x132391c, 0x4, 0x0, 0x0, 0x0, ...)
	/home/travis/gopath/src/github.com/lunarway/shuttle/pkg/config/shuttleconfig.go:38 +0x63
github.com/lunarway/shuttle/cmd.getProjectContext(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/travis/gopath/src/github.com/lunarway/shuttle/cmd/root.go:77 +0x197
github.com/lunarway/shuttle/cmd.glob..func6(0x15659e0, 0xc00000a7c0, 0x0, 0x2)
	/home/travis/gopath/src/github.com/lunarway/shuttle/cmd/ls.go:26 +0x37
github.com/spf13/cobra.(*Command).execute(0x15659e0, 0xc00000a760, 0x2, 0x2, 0x15659e0, 0xc00000a760)
	/home/travis/gopath/src/github.com/spf13/cobra/command.go:766 +0x2cc
github.com/spf13/cobra.(*Command).ExecuteC(0x15665c0, 0x8, 0x9, 0xc0000bc380)
	/home/travis/gopath/src/github.com/spf13/cobra/command.go:852 +0x2fd
github.com/spf13/cobra.(*Command).Execute(0x15665c0, 0x1566360, 0xc0000dbf20)
	/home/travis/gopath/src/github.com/spf13/cobra/command.go:800 +0x2b
github.com/lunarway/shuttle/cmd.Execute()
	/home/travis/gopath/src/github.com/lunarway/shuttle/cmd/root.go:49 +0x3f
main.main()
	/home/travis/gopath/src/github.com/lunarway/shuttle/main.go:8 +0x20
```

This change reports if the file is missing or invalid along with some guidance on what to do next.

```
$ ./shuttle -p examples ls
shuttle failed
Failed to load shuttle configuration: open /Users/bjornsorensen/gitRepo/shuttle/examples/shuttle.yaml: no such file or directory

Make sure you are in a project using shuttle and that a 'shuttle.yaml' file is available.

$ ./shuttle -p examples/bad/yaml-invalid ls
shuttle failed
Failed to parse shuttle configuration: yaml: unmarshal errors:
  line 3: cannot unmarshal !!float `23.1` into map[string]interface {}

Make sure your 'shuttle.yaml' is valid.
```
Closes #25