### PR TITLE
Fix problem with template function `array`

### DIFF
--- a/pkg/templates/funcs.go
+++ b/pkg/templates/funcs.go
@@ -119,7 +119,7 @@ func TmplObjectArray(path string, input interface{}) []KeyValuePair {
 		return nil
 	}
 	value := TmplGet(path, input)
-	var values []KeyValuePair
+	values := []KeyValuePair{}
 	switch value.(type) {
 	case map[interface{}]interface{}:
 		for k, v := range value.(map[interface{}]interface{}) {

--- a/pkg/templates/funcs_test.go
+++ b/pkg/templates/funcs_test.go
@@ -124,7 +124,7 @@ b:
 			},
 		},
 		{
-			name: "large string array testing for deterministic order",
+			name: "large string array testing for correct order",
 			input: input{
 				path: "a",
 				data: fromYaml(`a:
@@ -150,23 +150,47 @@ b:
 			},
 			output: []interface{}{
 				"b",
+				"d",
+				"e",
+				"g",
+				"h",
+				"f",
+				"i",
+				"s",
+				"k",
+				"c",
+				"l",
+				"m",
+				"n",
+				"o",
+				"r",
+				"j",
+				"p",
+				"q",
+			},
+		},
+		{
+			name: "object testing for deterministic order",
+			input: input{
+				path: "a",
+				data: fromYaml(`a:
+  b: b 
+  d: d 
+  e: e 
+  g: g 
+  h: h 
+  f: f
+  c: c
+`),
+			},
+			output: []interface{}{
+				"b",
 				"c",
 				"d",
 				"e",
 				"f",
 				"g",
 				"h",
-				"i",
-				"j",
-				"k",
-				"l",
-				"m",
-				"n",
-				"o",
-				"p",
-				"q",
-				"r",
-				"s",
 			},
 		},
 	}


### PR DESCRIPTION
The new deterministic idea of `array` introduced in commit
#714fc54083293966c35ebadfdae1923e88b0f509 changed the behavior in a
problematic way, since it resorted already deterministic sorted string
arrays into being sorted by value.

Working with the bug, I've found that the previous behavior also had
bugs too, including not handling maps correctly.
The new implementation now handles maps and also handle those in the
same deterministic way as objectArray.