### PR TITLE
Handle templates not co-located in projects

### DIFF
--- a/examples/custom-template.tmpl
+++ b/examples/custom-template.tmpl
@@ -1,0 +1,14 @@
+# Custom docker file template not located inside a project
+FROM golang:{{ get "GO_VERSION" .Args }}-alpine as builder
+
+LABEL custom=field
+
+COPY . /go
+
+RUN go build -v -o app
+
+FROM alpine
+
+COPY --from=builder /go/app /app
+
+ENTRYPOINT [ "/app" ]

--- a/tests.sh
+++ b/tests.sh
@@ -124,5 +124,9 @@ test_run_shell_error_outputs_missing_arg() {
   fi
 }
 
+test_template_local_path() {
+  assertErrorCode 0 -p examples/moon-base template ../custom-template.tmpl -o Dockerfile-custom
+}
+
 # Load and run shUnit2.
 . ./shunit2


### PR DESCRIPTION
If a shuttle template command is run on a template not inside the
project the template name does not resolve to the rigth template.

This change ensures to execute the named template based on the
path's base name.

I refactored the output handling as well to avoid having two
tmpl.Execute calls.