### PR TITLE
Add support for plan branches and overloading plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,10 @@ When using a git plan a url should look like:
 * `git@github.com:lunarway/shuttle-example-go-plan.git#change-build`
 
 The `#change-build` points the plan to a specific branch, which by default would be `master`.
-It can also be used to point to a tag or a git SHA.
+It can also be used to point to a tag or a git SHA, like this:
+
+* `https://github.com/lunarway/shuttle-example-go-plan.git#v1.2.3`
+* `git@github.com:lunarway/shuttle-example-go-plan.git#46ce3cc`
 
 ### Overloading the plan
 It is possible to overload the plan specified in `shuttle.yaml` file by using the `--plan` argument

--- a/README.md
+++ b/README.md
@@ -92,8 +92,26 @@ $ shuttle run build tag=v1
 * ...
 
 ## Documentation
-*Documentation is coming*
+*Documentation is under development*
 
+### Git Plan
+When using a git plan a url should look like:
+
+* `https://github.com/lunarway/shuttle-example-go-plan.git`
+* `git@github.com:lunarway/shuttle-example-go-plan.git`
+* `https://github.com/lunarway/shuttle-example-go-plan.git#change-build`
+* `git@github.com:lunarway/shuttle-example-go-plan.git#change-build`
+
+The `#change-build` points the plan to a specific branch, which by default would be `master`.
+It can also be used to point to a tag or a git SHA.
+
+### Overloading the plan
+It is possible to overload the plan specified in `shuttle.yaml` file by using the `--plan` argument
+or the `SHUTTLE_PLAN_OVERLOAD` environment variable. Following arguments are supported
+
+* A path to a local plan like `--plan ../local-checkout-of-plan`. Absolute paths is also supported
+* Another git plan like `--plan git://github.com/some-org/some-plan`
+* A git tag to append to the plan like `--plan #some-branch`, `--plan #some-tag` or a SHA `--plan #2b52c21` 
 
 ## Installing
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,7 +57,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&clean, "clean", "c", false, "Start from clean setup")
 	rootCmd.PersistentFlags().BoolVar(&skipGitPlanPulling, "skip-pull", false, "Skip git plan pulling step")
 	rootCmd.PersistentFlags().StringVar(&plan, "plan", "", `Overload the plan used.
-Specifying a local path with either a absolute path (/some/plan) or a relative path (../some/plan) to another location
+Specifying a local path with either an absolute path (/some/plan) or a relative path (../some/plan) to another location
 for the selected plan.
 Select a version of a git plan by using #branch, #sha or #tag
 If none of above is used, then the argument will expect a full plan spec.`)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ var (
 	verboseFlag        bool
 	clean              bool
 	skipGitPlanPulling bool
+	plan               string
 	version            = "<dev-version>"
 	commit             = "<unspecified-commit>"
 )
@@ -55,6 +56,11 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&projectPath, "project", "p", ".", "Project path")
 	rootCmd.PersistentFlags().BoolVarP(&clean, "clean", "c", false, "Start from clean setup")
 	rootCmd.PersistentFlags().BoolVar(&skipGitPlanPulling, "skip-pull", false, "Skip git plan pulling step")
+	rootCmd.PersistentFlags().StringVar(&plan, "plan", "", `Overload the plan used.
+Specifying a local path with either a absolute path (/some/plan) or a relative path (../some/plan) to another location
+for the selected plan.
+Select a version of a git plan by using #branch, #sha or #tag
+If none of above is used, then the argument will expect a full plan spec.`)
 	rootCmd.PersistentFlags().BoolVarP(&verboseFlag, "verbose", "v", false, "Print verbose output")
 }
 
@@ -72,7 +78,14 @@ func getProjectContext() config.ShuttleProjectContext {
 		fullProjectPath = path.Join(dir, projectPath)
 	}
 
+	if plan == "" {
+		env := os.Getenv("SHUTTLE_PLAN_OVERLOAD")
+		if env != "" {
+			plan = env
+		}
+	}
+
 	var c config.ShuttleProjectContext
-	c.Setup(fullProjectPath, uii, clean, skipGitPlanPulling)
+	c.Setup(fullProjectPath, uii, clean, skipGitPlanPulling, plan)
 	return c
 }

--- a/examples/repo-project-branched/main.go
+++ b/examples/repo-project-branched/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	println("hello world!")
+}

--- a/examples/repo-project-branched/shuttle.yaml
+++ b/examples/repo-project-branched/shuttle.yaml
@@ -1,4 +1,4 @@
-plan: 'https://github.com/lunarway/shuttle-example-go-plan.git'
+plan: 'https://github.com/lunarway/shuttle-example-go-plan.git#change-build'
 vars:
   docker:
     baseImage: golang

--- a/pkg/config/planargument.go
+++ b/pkg/config/planargument.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"github.com/lunarway/shuttle/pkg/git"
+	"os"
+	"path"
+	"strings"
+)
+
+func isPlanArgumentAFilePlan(planArgument string) bool {
+	return strings.Index(planArgument, "/") == 0 || strings.Index(planArgument, "./") == 0 || strings.Index(planArgument, "../") == 0
+}
+
+func isPlanArgumentAPlan(planArgument string) bool {
+	return planArgument != "" && (git.IsGitPlan(planArgument) || isPlanArgumentAFilePlan(planArgument))
+}
+
+func getPlanFromPlanArgument(planArgument string) string {
+	switch {
+	case isPlanArgumentAFilePlan(planArgument) && isFilePath(planArgument, true):
+		return planArgument
+	case isPlanArgumentAFilePlan(planArgument) && isFilePath(planArgument, false):
+		wd, err := os.Getwd()
+		if err != nil {
+			panic(err)
+		}
+		return path.Join(wd, planArgument)
+	default:
+		return planArgument
+	}
+}

--- a/pkg/config/planargument.go
+++ b/pkg/config/planargument.go
@@ -8,7 +8,7 @@ import (
 )
 
 func isPlanArgumentAFilePlan(planArgument string) bool {
-	return strings.Index(planArgument, "/") == 0 || strings.Index(planArgument, "./") == 0 || strings.Index(planArgument, "../") == 0
+	return strings.HasPrefix(planArgument, "/") || strings.HasPrefix(planArgument, "./") || strings.HasPrefix(planArgument, "../")
 }
 
 func isPlanArgumentAPlan(planArgument string) bool {

--- a/pkg/config/planargument.go
+++ b/pkg/config/planargument.go
@@ -17,8 +17,6 @@ func isPlanArgumentAPlan(planArgument string) bool {
 
 func getPlanFromPlanArgument(planArgument string) string {
 	switch {
-	case isPlanArgumentAFilePlan(planArgument) && isFilePath(planArgument, true):
-		return planArgument
 	case isPlanArgumentAFilePlan(planArgument) && isFilePath(planArgument, false):
 		wd, err := os.Getwd()
 		if err != nil {

--- a/pkg/config/shuttleconfig.go
+++ b/pkg/config/shuttleconfig.go
@@ -6,7 +6,7 @@ import (
 	"path"
 
 	"github.com/lunarway/shuttle/pkg/ui"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 // DynamicYaml are any yaml document
@@ -33,7 +33,7 @@ type ShuttleProjectContext struct {
 }
 
 // Setup the ShuttleProjectContext for a specific path
-func (c *ShuttleProjectContext) Setup(projectPath string, uii ui.UI, clean bool, skipGitPlanPulling bool) *ShuttleProjectContext {
+func (c *ShuttleProjectContext) Setup(projectPath string, uii ui.UI, clean bool, skipGitPlanPulling bool, planArgument string) *ShuttleProjectContext {
 	c.Config.getConf(uii, projectPath)
 	c.UI = uii
 	c.ProjectPath = projectPath
@@ -46,7 +46,7 @@ func (c *ShuttleProjectContext) Setup(projectPath string, uii ui.UI, clean bool,
 	os.MkdirAll(c.LocalShuttleDirectoryPath, os.ModePerm)
 
 	c.TempDirectoryPath = path.Join(c.LocalShuttleDirectoryPath, "temp")
-	c.LocalPlanPath = FetchPlan(c.Config.Plan, projectPath, c.LocalShuttleDirectoryPath, uii, skipGitPlanPulling)
+	c.LocalPlanPath = FetchPlan(c.Config.Plan, projectPath, c.LocalShuttleDirectoryPath, uii, skipGitPlanPulling, planArgument)
 	c.Plan.Load(c.LocalPlanPath)
 	c.Scripts = make(map[string]ShuttlePlanScript)
 	for scriptName, script := range c.Plan.Scripts {

--- a/pkg/config/shuttleplan.go
+++ b/pkg/config/shuttleplan.go
@@ -67,23 +67,27 @@ func (p *ShuttlePlanConfiguration) Load(planPath string) *ShuttlePlanConfigurati
 }
 
 // FetchPlan so it exists locally and return path to that plan
-func FetchPlan(plan string, projectPath string, localShuttleDirectoryPath string, uii ui.UI, skipGitPlanPulling bool) string {
+func FetchPlan(plan string, projectPath string, localShuttleDirectoryPath string, uii ui.UI, skipGitPlanPulling bool, planArgument string) string {
+	if isPlanArgumentAPlan(planArgument) {
+		uii.Infoln("Using overloaded plan %v", planArgument)
+		return FetchPlan(getPlanFromPlanArgument(planArgument), projectPath, localShuttleDirectoryPath, uii, skipGitPlanPulling, "")
+	}
+	
 	switch {
 	case plan == "":
 		uii.Verboseln("Using no plan")
 		return ""
 	case git.IsGitPlan(plan):
 		uii.Verboseln("Using git plan at '%s'", plan)
-		return git.GetGitPlan(plan, localShuttleDirectoryPath, uii, skipGitPlanPulling)
+		return git.GetGitPlan(plan, localShuttleDirectoryPath, uii, skipGitPlanPulling, planArgument)
 	case isMatching("^http://|^https://", plan):
-		panic("plan not valid: http is not supported yet")
+		panic(fmt.Sprintf("Plan '%v' is not valid: non-git http/https is not supported yet", plan))
 	case isFilePath(plan, true):
 		uii.Verboseln("Using local plan at '%s'", plan)
 		return plan
 	case isFilePath(plan, false):
 		uii.Verboseln("Using local plan at '%s'", plan)
 		return path.Join(projectPath, plan)
-
 	}
 	panic("Unknown plan path '" + plan + "'")
 }

--- a/pkg/git/main.go
+++ b/pkg/git/main.go
@@ -73,7 +73,7 @@ func IsGitPlan(plan string) bool {
 func GetGitPlan(plan string, localShuttleDirectoryPath string, uii ui.UI, skipGitPlanPulling bool, planArgument string) string {
 	parsedGitPlan := parseGitPlan(plan)
 
-	if strings.Index(planArgument, "#") == 0 {
+	if strings.HasPrefix(planArgument, "#") {
 		parsedGitPlan.head = planArgument[1:]
 		uii.EmphasizeInfoln("Overload git plan branch/tag/sha with %v", parsedGitPlan.head)
 	}

--- a/pkg/git/main.go
+++ b/pkg/git/main.go
@@ -127,8 +127,7 @@ func GetGitPlan(plan string, localShuttleDirectoryPath string, uii ui.UI, skipGi
 		}
 
 		uii.Infoln("Cloning plan %s", cloneArg)
-		gitCmd("clone "+cloneArg+" plan", localShuttleDirectoryPath, uii)
-		gitCmd(fmt.Sprintf("checkout %v", parsedGitPlan.head), localShuttleDirectoryPath, uii)
+		gitCmd(fmt.Sprintf("clone %v --branch %v plan", cloneArg, parsedGitPlan.head), localShuttleDirectoryPath, uii)
 	}
 
 	return planPath

--- a/pkg/git/main.go
+++ b/pkg/git/main.go
@@ -20,9 +20,10 @@ type gitPlan struct {
 	user       string
 	host       string
 	repository string
+	head       string
 }
 
-var gitRegex = regexp.MustCompile(`^git://((?P<user>[^@]+)@)?(?P<repository1>(?P<host>[^:]+):(?P<path>.*))$|^(?P<protocol>https)://(?P<repository2>.*\.git)$`)
+var gitRegex = regexp.MustCompile(`^((git://((?P<user>[^@]+)@)?(?P<repository1>(?P<host>[^:]+):(?P<path>.*)))|((?P<protocol>https)://(?P<repository2>.*\.git)))(#(?P<head>.*))?$`)
 
 func parseGitPlan(plan string) gitPlan {
 	if !gitRegex.MatchString(plan) {
@@ -47,6 +48,10 @@ func parseGitPlan(plan string) gitPlan {
 	if repository == "" {
 		repository = result["repository2"]
 	}
+	head := result["head"]
+	if head == "" {
+		head = "master"
+	}
 
 	return gitPlan{
 		isGitPlan:  true,
@@ -54,6 +59,7 @@ func parseGitPlan(plan string) gitPlan {
 		user:       result["user"],
 		host:       result["host"],
 		repository: repository,
+		head:       head,
 	}
 }
 
@@ -64,8 +70,14 @@ func IsGitPlan(plan string) bool {
 }
 
 // GetGitPlan will pull git repository and return its path
-func GetGitPlan(plan string, localShuttleDirectoryPath string, uii ui.UI, skipGitPlanPulling bool) string {
+func GetGitPlan(plan string, localShuttleDirectoryPath string, uii ui.UI, skipGitPlanPulling bool, planArgument string) string {
 	parsedGitPlan := parseGitPlan(plan)
+
+	if strings.Index(planArgument, "#") == 0 {
+		parsedGitPlan.head = planArgument[1:]
+		uii.EmphasizeInfoln("Overload git plan branch/tag/sha with %v", parsedGitPlan.head)
+	}
+
 	planPath := path.Join(localShuttleDirectoryPath, "plan")
 
 	plansAlreadyValidated := strings.Split(os.Getenv("SHUTTLE_PLANS_ALREADY_VALIDATED"), string(os.PathListSeparator))
@@ -89,10 +101,17 @@ func GetGitPlan(plan string, localShuttleDirectoryPath string, uii ui.UI, skipGi
 				uii.Verboseln("Skipping git plan pulling")
 				return planPath
 			}
-
-			uii.Infoln("Pulling latest plan changes")
+			gitCmd("fetch origin", planPath, uii)
+			gitCmd(fmt.Sprintf("checkout %s", parsedGitPlan.head), planPath, uii)
+			status := getStatus(planPath)
+			if !status.isDetached {
+				uii.Infoln("Pulling latest plan changes on %v", parsedGitPlan.head)
+				gitCmd("pull origin", planPath, uii)
+				status = getStatus(planPath)
+			} else {
+				uii.EmphasizeInfoln("Skipping plan pull because its running on detached head")
+			}
 			uii.Verboseln("Using %s - branch %s - commit %s", plan, status.branch, status.commit)
-			gitCmd("pull origin", planPath, uii)
 		}
 		return planPath
 	} else {
@@ -109,6 +128,7 @@ func GetGitPlan(plan string, localShuttleDirectoryPath string, uii ui.UI, skipGi
 
 		uii.Infoln("Cloning plan %s", cloneArg)
 		gitCmd("clone "+cloneArg+" plan", localShuttleDirectoryPath, uii)
+		gitCmd(fmt.Sprintf("checkout %v", parsedGitPlan.head), localShuttleDirectoryPath, uii)
 	}
 
 	return planPath

--- a/pkg/git/status.go
+++ b/pkg/git/status.go
@@ -36,6 +36,7 @@ type Status struct {
 	commit       string
 	branch       string
 	remoteBranch string
+	isDetached   bool
 }
 
 type FileStatus struct {
@@ -61,7 +62,11 @@ func getStatus(dir string) Status {
 			case "branch.oid":
 				status.commit = parts[2]
 			case "branch.head":
-				status.branch = parts[2]
+				if parts[2] == "(detached)" {
+					status.isDetached = true
+				} else {
+					status.branch = parts[2]
+				}
 			case "branch.upsteam":
 				status.remoteBranch = parts[2]
 			case "branch.ab":

--- a/run
+++ b/run
@@ -1,2 +1,3 @@
 #!/bin/bash
-go run main.go "$@"
+go build
+./shuttle "$@"

--- a/tests.sh
+++ b/tests.sh
@@ -131,7 +131,7 @@ test_template_local_path() {
 test_run_repo_say_branch() {
   result=$(./shuttle -p examples/repo-project-branched run say)
   if [[ ! "$result" =~ "something clever" ]]; then
-    fail "Expected output to contain 'something minor', but it was:\n$result"
+    fail "Expected output to contain 'something clever', but it was:\n$result"
   fi
 }
 

--- a/tests.sh
+++ b/tests.sh
@@ -47,8 +47,8 @@ test_can_get_variable_from_local_plan() {
 }
 
 test_can_get_variable_from_repo_plan() {
-  result=$(./shuttle -p examples/repo-project get docker.image 2>&1)
-  assertEquals "shuttle/repo-project" "$result"
+  result=$(./shuttle -p examples/repo-project get docker.destImage 2>&1)
+  assertEquals "repo-project" "$result"
 }
 
 test_fails_getting_no_repo_plan() {
@@ -127,6 +127,35 @@ test_run_shell_error_outputs_missing_arg() {
 test_template_local_path() {
   assertErrorCode 0 -p examples/moon-base template ../custom-template.tmpl -o Dockerfile-custom
 }
+
+test_run_repo_say_branch() {
+  result=$(./shuttle -p examples/repo-project-branched run say)
+  if [[ ! "$result" =~ "something clever" ]]; then
+    fail "Expected output to contain 'something minor', but it was:\n$result"
+  fi
+}
+
+test_run_repo_say() {
+  result=$(./shuttle -p examples/repo-project run say)
+  if [[ ! "$result" =~ "something masterly" ]]; then
+    fail "Expected output to contain 'something', but it was:\n$result"
+  fi
+}
+
+test_run_repo_say_tagged() {
+  result=$(./shuttle -p examples/repo-project --plan "#tagged" run say)
+  if [[ ! "$result" =~ "something tagged" ]]; then
+    fail "Expected output to contain 'something', but it was:\n$result"
+  fi
+}
+
+test_run_repo_say_sha() {
+  result=$(./shuttle -p examples/repo-project --plan "#2b52c21" run say)
+  if [[ ! "$result" =~ "something minor" ]]; then
+    fail "Expected output to contain 'something minor', but it was:\n$result"
+  fi
+}
+
 
 # Load and run shUnit2.
 . ./shunit2

--- a/tests.sh
+++ b/tests.sh
@@ -138,7 +138,7 @@ test_run_repo_say_branch() {
 test_run_repo_say() {
   result=$(./shuttle -p examples/repo-project run say)
   if [[ ! "$result" =~ "something masterly" ]]; then
-    fail "Expected output to contain 'something', but it was:\n$result"
+    fail "Expected output to contain 'something masterly', but it was:\n$result"
   fi
 }
 

--- a/tests.sh
+++ b/tests.sh
@@ -145,7 +145,7 @@ test_run_repo_say() {
 test_run_repo_say_tagged() {
   result=$(./shuttle -p examples/repo-project --plan "#tagged" run say)
   if [[ ! "$result" =~ "something tagged" ]]; then
-    fail "Expected output to contain 'something', but it was:\n$result"
+    fail "Expected output to contain 'something tagged', but it was:\n$result"
   fi
 }
 


### PR DESCRIPTION
With this PR shuttle will support setting the branch of a plan, like:
```
plan: git@github.com:lunarway/shuttle-example-go-plan.git#change-build
```
The `shuttle` CLI also supports 2 other new features to help develop
plans. Both is about overloading the current plan:

* A new flag `--plan`
* An environment variable `SHUTTLE_PLAN_OVERLOAD`

content of these two are handled the same, but the flag will take precedence
over the environment variable.

Setting the overload to a full plan specifier will change the plan fully. This
allows us to fx point a project to same plan in another directory, thus we can
develop one plan easily for multiple project.
Setting the overload to `#some-branch`, `#some-tag`, `#2b52c21` will change a
git plan's to target branch, tag or sha.