### PR TITLE
Add plan command

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ or the `SHUTTLE_PLAN_OVERLOAD` environment variable. Following arguments are sup
 
 * A path to a local plan like `--plan ../local-checkout-of-plan`. Absolute paths is also supported
 * Another git plan like `--plan git://github.com/some-org/some-plan`
-* A git tag to append to the plan like `--plan #some-branch`, `--plan #some-tag` or a SHA `--plan #2b52c21` 
+* A git tag to append to the plan like `--plan #some-branch`, `--plan #some-tag` or a SHA `--plan #2b52c21`
 
 ## Installing
 
@@ -145,6 +145,15 @@ $ shuttle get some.variable
 
 $ shuttle get does.not.exist
 > # nothing
+```
+
+### `shuttle plan`
+Inspec the plan in use for a project.
+Use the `template` flag to customize the output to your needs.
+
+```console
+$ shuttle plan
+https://github.com/lunarway/shuttle-example-go-plan.git
 ```
 
 ### `shuttle has <variable>`

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ $ shuttle get does.not.exist
 ```
 
 ### `shuttle plan`
-Inspec the plan in use for a project.
+Inspect the plan in use for a project.
 Use the `template` flag to customize the output to your needs.
 
 ```console

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/lunarway/shuttle/pkg/ui"
+	"github.com/spf13/cobra"
+)
+
+const planDefaultTempl = `{{.Plan}}`
+
+var (
+	planFlagTemplate string
+)
+
+var planCmd = &cobra.Command{
+	Use:   "plan",
+	Short: "Output plan information to stdout",
+	Long: `Output plan information to stdout.
+By default the plan name is output. For projects without a plan (plan: false) an
+empty string is written.
+
+Configure the output with a template variable. The format is Go templates.
+See http://golang.org/pkg/text/template/#pkg-overview for more details.
+
+Available fields are:
+
+  .LocalPlanPath     Path to the plan on the local file system.
+  .Plan              Pretty plan string. Empty if no plan is set.
+  .PlanRaw           Raw plan string as read from the configuration.
+  .ProjectPath       Path to the current project.
+  .TempDirectoryPath Path to the temporary files of the plan on the local file
+                     system.
+`,
+	Example: `Get the raw plan string as it is written in the shuttle.yaml file:
+  shuttle plan --template '{{.PlanRaw}}'`,
+	Args: cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		type templData struct {
+			LocalPlanPath     string
+			Plan              string
+			PlanRaw           interface{}
+			ProjectPath       string
+			TempDirectoryPath string
+		}
+		uii = uii.SetUserLevel(ui.LevelError)
+		context := getProjectContext()
+		var templ string
+		if planFlagTemplate != "" {
+			templ = planFlagTemplate
+		} else {
+			templ = planDefaultTempl
+		}
+		err := ui.Template(os.Stdout, "plan", templ, templData{
+			Plan:              context.Config.Plan,
+			PlanRaw:           context.Config.PlanRaw,
+			LocalPlanPath:     context.LocalPlanPath,
+			ProjectPath:       context.ProjectPath,
+			TempDirectoryPath: context.TempDirectoryPath,
+		})
+		context.UI.CheckIfError(err)
+	},
+}
+
+func init() {
+	planCmd.Flags().StringVar(&planFlagTemplate, "template", "", "Template string to use. See --help for details.")
+	rootCmd.AddCommand(planCmd)
+}

--- a/examples/no-plan-project/shuttle.yaml
+++ b/examples/no-plan-project/shuttle.yaml
@@ -1,0 +1,7 @@
+plan: false
+vars:
+  T: hello
+scripts:
+  hello:
+    actions:
+    - shell: echo "Hello no plan project"

--- a/pkg/ui/main.go
+++ b/pkg/ui/main.go
@@ -76,7 +76,7 @@ func (ui *UI) Titleln(format string, args ...interface{}) {
 
 // Errorln doc
 func (ui *UI) Errorln(format string, args ...interface{}) {
-	if ui.EffectiveLevel.OutputIsIncluded(LevelInfo) {
+	if ui.EffectiveLevel.OutputIsIncluded(LevelError) {
 		fmt.Fprintf(os.Stderr, "\x1b[31;1m%s\x1b[0m\n", fmt.Sprintf(format, args...))
 	}
 }

--- a/tests.sh
+++ b/tests.sh
@@ -46,6 +46,31 @@ test_can_get_variable_from_local_plan() {
   assertEquals "earth-united/moon-base" "$result"
 }
 
+test_plan_from_relative_local_plan() {
+  result=$(./shuttle -p examples/moon-base plan 2>&1)
+  assertEquals "../station-plan" "$result"
+}
+
+test_plan_from_git_plan() {
+  result=$(./shuttle -p examples/repo-project plan 2>&1)
+  assertEquals "https://github.com/lunarway/shuttle-example-go-plan.git" "$result"
+}
+
+test_plan_from_git_plan_with_branch() {
+  result=$(./shuttle -p examples/repo-project-branched plan 2>&1)
+  assertEquals "https://github.com/lunarway/shuttle-example-go-plan.git#change-build" "$result"
+}
+
+test_plan_from_no_plan() {
+  result=$(./shuttle -p examples/no-plan-project plan 2>&1)
+  assertEquals "" "$result"
+}
+
+test_plan_with_template_from_no_plan() {
+  result=$(./shuttle -p examples/no-plan-project plan --template '{{.PlanRaw}}' 2>&1)
+  assertEquals "false" "$result"
+}
+
 test_can_get_variable_from_repo_plan() {
   result=$(./shuttle -p examples/repo-project get docker.destImage 2>&1)
   assertEquals "repo-project" "$result"


### PR DESCRIPTION
This change set adds a `plan` command to the root command.

It makes it possible to inspect details about the current used plan in a shuttle project.

There is also a bug fix for the error logging level handling.