### PR TITLE
Add template flag to get command for customization

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -12,6 +13,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	getFlagTemplate string
+)
+
 type dynamicValue = interface{}
 
 var getCmd = &cobra.Command{
@@ -20,10 +25,19 @@ var getCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	//Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		uii = uii.SetContext(ui.LevelSilent)
+		uii = uii.SetContext(ui.LevelError)
 		context := getProjectContext()
 		path := args[0]
+		var templ string
+		if getFlagTemplate != "" {
+			templ = getFlagTemplate
+		}
 		value := templates.TmplGet(path, context.Config.Variables)
+		if templ != "" {
+			err := ui.Template(os.Stdout, "get", templ, value)
+			context.UI.CheckIfError(err)
+			return
+		}
 		switch value.(type) {
 		case nil:
 			// print nothing
@@ -38,5 +52,6 @@ var getCmd = &cobra.Command{
 }
 
 func init() {
+	getCmd.Flags().StringVar(&getFlagTemplate, "template", "", "Template string to use. See --help for details.")
 	rootCmd.AddCommand(getCmd)
 }

--- a/tests.sh
+++ b/tests.sh
@@ -46,6 +46,11 @@ test_can_get_variable_from_local_plan() {
   assertEquals "earth-united/moon-base" "$result"
 }
 
+test_can_get_variable_from_local_plan_with_templating() {
+  result=$(./shuttle -p examples/moon-base get docker --template '{{ range $k, $v := . }}{{ $k }}{{ end }}' 2>&1)
+  assertEquals "image" "$result"
+}
+
 test_plan_from_relative_local_plan() {
   result=$(./shuttle -p examples/moon-base plan 2>&1)
   assertEquals "../station-plan" "$result"


### PR DESCRIPTION
This makes it more powerful for users to customize the results to their
needs with Go templating.

The added test, as an example, outputs the keys of the `docker` object instead of the value.

```yaml
plan: '../station-plan'
vars:
  docker:
    image: earth-united/moon-base
  run-as-root: false
```

```
$ shuttle -p examples/moon-base get docker --template '{{ range $k, $v := . }}{{ $k }} {{ end }}'
image
```