### PR TITLE
Add documentation to templating functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,42 @@ $ shuttle has my.docker.image --stdout
 > false
 ```
 
+### Template functions
+The `template` command along with commands taking a `--template` flag has multiple templating functions available.
+Examples are based on the below `shuttle.yaml` file.
 
+|Function|Description|Example|Output|
+|---|---|---|---|
+|`get <path> <value>`|Get a value from a field path. `.` is read as nested nested objects| `get "docker.image" .` | `earth-united/moon-base`|
+|`string <path> <value>`|Format any value as a string.|`string "replicas" .` | `"1"` |
+|`array <path> <value>`|Get array from path. If value is a map, the values of the map is returned in deterministic order. | `array "args" .` | `helloworld`|
+|`objectArray <path> <value>`|Get object key-value pairs from path. Each key-value is returned in a `{ Key Value}` object. | `{{ range objectArray "docker" . }}{{ .Key }} -> {{ .Value }}{{ end }}` | `image -> earth-united/moon-base`|
+|`strConst <value>`|Convert string to upper snake casing converting `.` to `_`.|`strConst "a.value"` | `A_VALUE`|
+|`int <path> <value>`|Get int value without formatting. Note that this is a direct `int` cast ie. value `1.2` will generate an error.|`int "replicas" .`|`1`
+|`is <value-a> <value-b>`|Equality indication by Go's `==` comparison.|`is "foo" "bar"`| `false`|
+|`isnt <value-a> <value-b>`|Inequality indication by Go's `!=` comparison.|`isnt "foo" "bar"`| `true`|
+|`toYaml <value>`| Marshal value to YAML. In case of non-parsable string an empty string is returned. See notes below on usage.|`toYaml (get "args" .)`| `- hello`<br>`- world`|
+|`fromYaml <value>`| Unmarshal YAML string to a `map[string]interface{}`. In case of YAML parsing errors the `Error` key in the result contains the error message. See notes below on usage.|`fromYaml "api: v1"` | `map[api:v1]`
+|`getFiles <directory-path>`|Returns a slice of files in the provided directory as [`os.FileInfo`](https://golang.org/pkg/os/#FileInfo) structs.|`{{ range $i, $f := (getFiles "./") }}{{ .Name }} {{ end }}`| `.git .gitignore ...`
+|`getFileContent <file-path>`|Get raw contents of a file.|`getFileContent ".gitignore"`|`dist/`<br>`vendor/`<br>`...`|
+|`fileExists <file-path>`|Returns whether a file exists.|`fileExists ".gitignore"`|`true`|
+|`trim <string>`|Trim leading and trailing whitespaces. Uses [`strings.TrimSpace`](https://golang.org/pkg/strings/#TrimSpace).|`trim " a string "`|`a string`
+|`upperFirst <string>`|Upper case first character in string.|`upperFirst "a string"`|`A string`|
+|`rightPad <string> <padding>`|Add space padding to the right of a string.|`{{ rightPad "padded" 10 }}string`|`padded    string`
+
+```yaml
+plan: ../the-plan
+vars:
+  docker:
+    image: earth-united/moon-base
+  replicas: 1
+  args:
+  - 'hello'
+  - 'world'
+```
+
+**Notes on YAML parsers**: The `toYaml` and `fromYaml` template functions are intented to be used inside file templates (not `template` flags).
+Because of this they ignore errors and some YAML documents canont be parsed.
 ## Release History
 
 See the [releases](https://github.com/lunarway/shuttle/releases) for more

--- a/README.md
+++ b/README.md
@@ -176,22 +176,22 @@ Examples are based on the below `shuttle.yaml` file.
 
 |Function|Description|Example|Output|
 |---|---|---|---|
-|`get <path> <value>`|Get a value from a field path. `.` is read as nested nested objects| `get "docker.image" .` | `earth-united/moon-base`|
-|`string <path> <value>`|Format any value as a string.|`string "replicas" .` | `"1"` |
 |`array <path> <value>`|Get array from path. If value is a map, the values of the map is returned in deterministic order. | `array "args" .` | `helloworld`|
-|`objectArray <path> <value>`|Get object key-value pairs from path. Each key-value is returned in a `{ Key Value}` object. | `{{ range objectArray "docker" . }}{{ .Key }} -> {{ .Value }}{{ end }}` | `image -> earth-united/moon-base`|
-|`strConst <value>`|Convert string to upper snake casing converting `.` to `_`.|`strConst "a.value"` | `A_VALUE`|
+|`fileExists <file-path>`|Returns whether a file exists.|`fileExists ".gitignore"`|`true`|
+|`fromYaml <value>`| Unmarshal YAML string to a `map[string]interface{}`. In case of YAML parsing errors the `Error` key in the result contains the error message. See notes below on usage.|`fromYaml "api: v1"` | `map[api:v1]`
+|`get <path> <value>`|Get a value from a field path. `.` is read as nested nested objects| `get "docker.image" .` | `earth-united/moon-base`|
+|`getFileContent <file-path>`|Get raw contents of a file.|`getFileContent ".gitignore"`|`dist/`<br>`vendor/`<br>`...`|
+|`getFiles <directory-path>`|Returns a slice of files in the provided directory as [`os.FileInfo`](https://golang.org/pkg/os/#FileInfo) structs.|`{{ range $i, $f := (getFiles "./") }}{{ .Name }} {{ end }}`| `.git .gitignore ...`
 |`int <path> <value>`|Get int value without formatting. Note that this is a direct `int` cast ie. value `1.2` will generate an error.|`int "replicas" .`|`1`
 |`is <value-a> <value-b>`|Equality indication by Go's `==` comparison.|`is "foo" "bar"`| `false`|
 |`isnt <value-a> <value-b>`|Inequality indication by Go's `!=` comparison.|`isnt "foo" "bar"`| `true`|
+|`objectArray <path> <value>`|Get object key-value pairs from path. Each key-value is returned in a `{ Key Value}` object. | `{{ range objectArray "docker" . }}{{ .Key }} -> {{ .Value }}{{ end }}` | `image -> earth-united/moon-base`|
+|`rightPad <string> <padding>`|Add space padding to the right of a string.|`{{ rightPad "padded" 10 }}string`|`padded    string`
+|`strConst <value>`|Convert string to upper snake casing converting `.` to `_`.|`strConst "a.value"` | `A_VALUE`|
+|`string <path> <value>`|Format any value as a string.|`string "replicas" .` | `"1"` |
 |`toYaml <value>`| Marshal value to YAML. In case of non-parsable string an empty string is returned. See notes below on usage.|`toYaml (get "args" .)`| `- hello`<br>`- world`|
-|`fromYaml <value>`| Unmarshal YAML string to a `map[string]interface{}`. In case of YAML parsing errors the `Error` key in the result contains the error message. See notes below on usage.|`fromYaml "api: v1"` | `map[api:v1]`
-|`getFiles <directory-path>`|Returns a slice of files in the provided directory as [`os.FileInfo`](https://golang.org/pkg/os/#FileInfo) structs.|`{{ range $i, $f := (getFiles "./") }}{{ .Name }} {{ end }}`| `.git .gitignore ...`
-|`getFileContent <file-path>`|Get raw contents of a file.|`getFileContent ".gitignore"`|`dist/`<br>`vendor/`<br>`...`|
-|`fileExists <file-path>`|Returns whether a file exists.|`fileExists ".gitignore"`|`true`|
 |`trim <string>`|Trim leading and trailing whitespaces. Uses [`strings.TrimSpace`](https://golang.org/pkg/strings/#TrimSpace).|`trim " a string "`|`a string`
 |`upperFirst <string>`|Upper case first character in string.|`upperFirst "a string"`|`A string`|
-|`rightPad <string> <padding>`|Add space padding to the right of a string.|`{{ rightPad "padded" 10 }}string`|`padded    string`
 
 ```yaml
 plan: ../the-plan


### PR DESCRIPTION
This change adds documentation to the available templating functions for the `template` command and the `--template` flag.