### PR TITLE
Validate script arguments

### DIFF
--- a/pkg/config/shuttleplan.go
+++ b/pkg/config/shuttleplan.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"fmt"
 	"os"
@@ -27,6 +28,18 @@ type ShuttleScriptArgs struct {
 	Name        string `yaml:"name"`
 	Required    bool   `yaml:"required"`
 	Description string `yaml:"description"`
+}
+
+func (a ShuttleScriptArgs) String() string {
+	var s strings.Builder
+	s.WriteString(a.Name)
+	if a.Required {
+		s.WriteString(" (required)")
+	}
+	if len(a.Description) != 0 {
+		fmt.Fprintf(&s, "  %s", a.Description)
+	}
+	return s.String()
 }
 
 // ShuttleAction describes an action done by a shuttle script

--- a/pkg/executors/executor_test.go
+++ b/pkg/executors/executor_test.go
@@ -12,7 +12,7 @@ func TestValidateUnknownArgs(t *testing.T) {
 		name       string
 		scriptArgs []config.ShuttleScriptArgs
 		inputArgs  map[string]string
-		output     []string
+		output     []validationError
 	}{
 		{
 			name:       "no input or script",
@@ -26,8 +26,8 @@ func TestValidateUnknownArgs(t *testing.T) {
 			inputArgs: map[string]string{
 				"foo": "1",
 			},
-			output: []string{
-				"'foo' unknown",
+			output: []validationError{
+				{"foo", "unknown"},
 			},
 		},
 		{
@@ -37,9 +37,9 @@ func TestValidateUnknownArgs(t *testing.T) {
 				"foo": "1",
 				"bar": "2",
 			},
-			output: []string{
-				"'foo' unknown",
-				"'bar' unknown",
+			output: []validationError{
+				{"bar", "unknown"},
+				{"foo", "unknown"},
 			},
 		},
 		{
@@ -65,8 +65,8 @@ func TestValidateUnknownArgs(t *testing.T) {
 				},
 			},
 			inputArgs: map[string]string{
-				"foo": "1",
 				"bar": "2",
+				"foo": "1",
 			},
 			output: nil,
 		},
@@ -85,15 +85,58 @@ func TestValidateUnknownArgs(t *testing.T) {
 				"bar": "2",
 				"baz": "3",
 			},
-			output: []string{
-				"'baz' unknown",
+			output: []validationError{
+				{"baz", "unknown"},
 			},
 		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			output := validateUnknownArgs(tc.scriptArgs, tc.inputArgs)
+			// sort as the order is not guarenteed by validateUnknownArgs
+			sortValidationErrors(output)
 			assert.Equal(t, tc.output, output, "output not as expected")
+		})
+	}
+}
+
+func TestSortValidationErrors(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  []validationError
+		output []validationError
+	}{
+		{
+			name: "sorted",
+			input: []validationError{
+				{"bar", ""},
+				{"baz", ""},
+				{"foo", ""},
+			},
+			output: []validationError{
+				{"bar", ""},
+				{"baz", ""},
+				{"foo", ""},
+			},
+		},
+		{
+			name: "not sorted",
+			input: []validationError{
+				{"baz", ""},
+				{"foo", ""},
+				{"bar", ""},
+			},
+			output: []validationError{
+				{"bar", ""},
+				{"baz", ""},
+				{"foo", ""},
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			sortValidationErrors(tc.input)
+			assert.Equal(t, tc.output, tc.input, "output not as expected")
 		})
 	}
 }

--- a/pkg/executors/executor_test.go
+++ b/pkg/executors/executor_test.go
@@ -1,0 +1,99 @@
+package executors
+
+import (
+	"testing"
+
+	"github.com/lunarway/shuttle/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateUnknownArgs(t *testing.T) {
+	tt := []struct {
+		name       string
+		scriptArgs []config.ShuttleScriptArgs
+		inputArgs  map[string]string
+		output     []string
+	}{
+		{
+			name:       "no input or script",
+			scriptArgs: nil,
+			inputArgs:  nil,
+			output:     nil,
+		},
+		{
+			name:       "single input without script",
+			scriptArgs: nil,
+			inputArgs: map[string]string{
+				"foo": "1",
+			},
+			output: []string{
+				"'foo' unknown",
+			},
+		},
+		{
+			name:       "multiple input without script",
+			scriptArgs: nil,
+			inputArgs: map[string]string{
+				"foo": "1",
+				"bar": "2",
+			},
+			output: []string{
+				"'foo' unknown",
+				"'bar' unknown",
+			},
+		},
+		{
+			name: "single input and script",
+			scriptArgs: []config.ShuttleScriptArgs{
+				{
+					Name: "foo",
+				},
+			},
+			inputArgs: map[string]string{
+				"foo": "1",
+			},
+			output: nil,
+		},
+		{
+			name: "multple input and script",
+			scriptArgs: []config.ShuttleScriptArgs{
+				{
+					Name: "foo",
+				},
+				{
+					Name: "bar",
+				},
+			},
+			inputArgs: map[string]string{
+				"foo": "1",
+				"bar": "2",
+			},
+			output: nil,
+		},
+		{
+			name: "multple input and script with one unknown",
+			scriptArgs: []config.ShuttleScriptArgs{
+				{
+					Name: "foo",
+				},
+				{
+					Name: "bar",
+				},
+			},
+			inputArgs: map[string]string{
+				"foo": "1",
+				"bar": "2",
+				"baz": "3",
+			},
+			output: []string{
+				"'baz' unknown",
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			output := validateUnknownArgs(tc.scriptArgs, tc.inputArgs)
+			assert.Equal(t, tc.output, output, "output not as expected")
+		})
+	}
+}

--- a/tests.sh
+++ b/tests.sh
@@ -159,6 +159,11 @@ test_run_shell_error_outputs_missing_arg() {
   fi
 }
 
+test_run_shell_error_outputs_unknown_argument() {
+  assertErrorCode 1 -p examples/moon-base run required-arg a=baz foo=bar
+  assertContains "'foo' unknown" "$result"
+}
+
 test_template_local_path() {
   assertErrorCode 0 -p examples/moon-base template ../custom-template.tmpl -o Dockerfile-custom
 }


### PR DESCRIPTION
If a user provides unknown arguments to a script this is silently ignored.

This can lead to time consuming typos, e.g. `versoin` instead of `version`.

This change set ensures that no unknown arguments can be applied to a script. It also detects all errors before stopping execution so unknown arguments, missing required arguments and non-parsable arguments are reported in one go.

```
$ shuttle --project examples/moon-base run required-arg b=1 d
shuttle failed
Arguments not valid:
 'd' not <argument>=<value>
 'a' not supplied but is required
 'b' unknown

Script 'required-arg' accepts the following arguments:
  a (required)
```

Lastly acceptable arguments are printed on any of the above errors to help users detect their mistakes fast.

This closes #38 