### PR TITLE
Support full build specs using steps

### DIFF
--- a/examples/station-plan/plan.yaml
+++ b/examples/station-plan/plan.yaml
@@ -1,4 +1,21 @@
 scripts:
+  ci:
+    description: Run all ci steps
+    args:
+      - name: tag
+        required: true
+    actions:
+      - step:
+          name: build
+          args:
+            tag: tag
+      - step:
+          name: test
+      - step:
+          name: deploy
+          args:
+            tag: tag
+
   build:
     description: Build the docker image
     args:
@@ -28,3 +45,9 @@ scripts:
       required: true
     actions:
     - shell: echo "Arg provided"
+  deploy:
+    description: Do a deploy (fake)
+    args:
+      - name: tag
+    actions:
+      - shell: echo "I would deploy $tag"

--- a/pkg/config/shuttleactionstep.go
+++ b/pkg/config/shuttleactionstep.go
@@ -1,0 +1,6 @@
+package config
+
+type ShuttleActionStep struct {
+	Name string            `yaml:"name"`
+	Args map[string]string `yaml:"args"`
+}

--- a/pkg/config/shuttleplan.go
+++ b/pkg/config/shuttleplan.go
@@ -44,8 +44,9 @@ func (a ShuttleScriptArgs) String() string {
 
 // ShuttleAction describes an action done by a shuttle script
 type ShuttleAction struct {
-	Shell      string `yaml:"shell"`
-	Dockerfile string `yaml:"dockerfile"`
+	Shell      string            `yaml:"shell"`
+	Dockerfile string            `yaml:"dockerfile"`
+	Step       ShuttleActionStep `yaml:"step"`
 }
 
 // ShuttlePlanConfiguration is a ShuttlePlan sub-element

--- a/pkg/executors/shell.go
+++ b/pkg/executors/shell.go
@@ -11,7 +11,7 @@ import (
 	go_cmd "github.com/go-cmd/cmd"
 )
 
-// Build builds the docker image from a shuttle plan
+// executeShell runs a shell script action
 func executeShell(context ActionExecutionContext) {
 	//log.Printf("Exec: %s", context.Action.Shell)
 	//cmdAndArgs := strings.Split(s.Shell, " ")

--- a/pkg/executors/step.go
+++ b/pkg/executors/step.go
@@ -1,0 +1,33 @@
+package executors
+
+import (
+	"fmt"
+	"github.com/lunarway/shuttle/pkg/config"
+	"time"
+)
+
+// executeStep runs another shuttle step
+func executeStep(context ActionExecutionContext) {
+	//shuttlePath, _ := filepath.Abs(filepath.Dir(os.Args[0]))
+	start := time.Now()
+	fmt.Println("--- Run " + context.Action.Step.Name)
+
+	var args []string
+	for argTo, argFrom := range context.Action.Step.Args  {
+		for k,v := range context.ScriptContext.Args {
+			if argFrom == k {
+				args = append(args, fmt.Sprintf("%s=%s", argTo,v))
+			}
+		}
+	}
+
+	Execute(context.ScriptContext.Project, context.Action.Step.Name, args)
+	fmt.Println(fmt.Sprintf("completed in %vs", time.Now().Sub(start).Seconds()))
+	fmt.Println("")
+}
+
+func init() {
+	addExecutor(func(action config.ShuttleAction) bool {
+		return action.Step.Name != ""
+	}, executeStep)
+}

--- a/tests.sh
+++ b/tests.sh
@@ -196,6 +196,21 @@ test_run_repo_say_sha() {
   fi
 }
 
+test_run_moon_base_ci_steps() {
+  result=$(./shuttle -p examples/moon-base run ci tag=mytag)
+
+  if [[ ! "$result" =~ "--- Run build" ]]; then
+    fail "Expected output to contain 'Run build', but it was:\n$result"
+  fi
+
+  if [[ ! "$result" =~ "--- Run test" ]]; then
+    fail "Expected output to contain 'Run test', but it was:\n$result"
+  fi
+
+  if [[ ! "$result" =~ "--- Run deploy" ]]; then
+    fail "Expected output to contain 'Run deploy', but it was:\n$result"
+  fi
+}
 
 # Load and run shUnit2.
 . ./shunit2


### PR DESCRIPTION
I had this idea to implement full CI plans using references between steps. This is my initial and early attempt to do that.

I've added a new part to the `space-station` example:

```
scripts:
  ci:
    description: Run all ci steps
    args:
      - name: tag
        required: true
    actions:
      - step:
          name: build
          args:
            tag: tag
      - step:
          name: test
      - step:
          name: deploy
          args:
            tag: tag
```

This one simply specs that it should run build, test and deploy in order. The args part is for mapping the `ci` commands args to each step.

I would love if it was possible to do `- step: test`, but I have to find a more clever way to implement that.

With something like this in place, it should be possible to do autogenerated Jenkins, Travis, Github actions or likewise scripts, that's just made directly from the shuttle plan. That - I think - would be really powerful.