### PR TITLE
Document sprig template functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ $ shuttle has my.docker.image --stdout
 
 ### Template functions
 The `template` command along with commands taking a `--template` flag has multiple templating functions available.
+The [masterminds/sprig](http://masterminds.github.io/sprig) functions are available along with those described below.
+
 Examples are based on the below `shuttle.yaml` file.
 
 |Function|Description|Example|Output|


### PR DESCRIPTION
We provide template functions from masterminds/sprig but it is not documented.

This changes documents that in the readme.