### PR TITLE
fix for empty output from git-plan command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-- "1.11.x"
+- "1.15.x"
 
 script: |
   echo "Build shuttle" &&

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/Masterminds/sprig v2.16.0+incompatible
 	github.com/aokoli/goutils v1.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-cmd/cmd v1.0.3
+	github.com/go-cmd/cmd v1.2.0
 	github.com/go-test/deep v1.0.1 // indirect
 	github.com/google/uuid v1.0.0 // indirect
 	github.com/huandu/xstrings v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-cmd/cmd v1.0.3 h1:N4lOnQy9gKNXLDnjoyRLLXG5sRqEzvFtdHjQysBez/g=
 github.com/go-cmd/cmd v1.0.3/go.mod h1:y8q8qlK5wQibcw63djSl/ntiHUHXHGdCkPk0j4QeW4s=
+github.com/go-cmd/cmd v1.2.0 h1:Aohz0ZG0nQbvT4z55Mh+fdegX48GSAXL3cSsbYxRfvI=
+github.com/go-cmd/cmd v1.2.0/go.mod h1:XgKkd0L6sv9WcYV0FS8RfG1RJCSTVHTsLeAD2pTgHt0=
 github.com/go-test/deep v1.0.1 h1:UQhStjbkDClarlmv0am7OXXO4/GaPdCGiUiMTvi28sg=
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=


### PR DESCRIPTION
We're seeing a sporadic issue when building projects with shuttle plans. Occasionally the tag of the docker image has an empty shuttlePlanHash (so the image tag would end up something like "master-e71d796c6e-")

This happens because the planHash() function in the shuttle.groovy file returns empty output. The function generates that output using './shuttle --skip-pull git-plan rev-parse HEAD'.

When looking at the source code of RunGitPlanCommand it looks like it might suffer from a race condition and exit prematurely before printing the output.

I had a look at the streaming example from https://github.com/go-cmd/cmd/blob/master/examples/blocking-streaming/main.go and basically copy-pasted that.