### PR TITLE
Fix goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,8 @@ builds:
   ldflags:
   - "-s -w -X github.com/lunarway/shuttle/cmd.version={{.Version}} -X github.com/lunarway/shuttle/cmd.commit={{.Commit}}"
 
-archive:
+archives:
+- id: archives
   format: binary
   name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
   replacements:


### PR DESCRIPTION
The archive field has been changed to an array and renamed to archives since we
last cut a release of shuttle.