### PR TITLE
Add run flag for skipping argument validation

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -15,12 +15,13 @@ var runCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		var commandName = args[0]
 		context := getProjectContext()
-		executors.Execute(context, commandName, args[1:])
+		executors.Execute(context, commandName, args[1:], validateArgs)
 	},
 }
 
 var (
 	flagTemplate string
+	validateArgs bool
 )
 
 func init() {
@@ -38,5 +39,6 @@ func init() {
 		}
 	})
 	runCmd.Flags().StringVar(&flagTemplate, "template", "", "Template string to use. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].")
+	runCmd.Flags().BoolVar(&validateArgs, "validate", true, "Validate arguments against script definition in plan and exit with 1 on unknown or missing arguments")
 	rootCmd.AddCommand(runCmd)
 }

--- a/tests.sh
+++ b/tests.sh
@@ -2,6 +2,12 @@
 
 go build
 
+# exit right away if build fails
+buildExitCode=$?
+if [[ $buildExitCode -ne 0 ]]; then
+  exit $buildExitCode
+fi
+
 function assertRun() {
   result=$(./shuttle "$@" 2>&1)
   result_status=$?
@@ -154,6 +160,23 @@ test_run_shell_error_outputs_missing_arg() {
   assertErrorCode 1 -p examples/moon-base run required-arg
   if [[ ! "$result" =~ "required-arg" ]]; then
     fail "Expected output to contain the script name 'required-arg', but it was:\n$result"
+  fi
+}
+
+test_run_shell_error_outputs_missing_arg_disabled_validation() {
+  assertErrorCode 0 -p examples/moon-base run --validate=false required-arg
+  if [[ "$result" =~ "required-arg" ]]; then
+    fail "Expected output not to contain the script name 'required-arg', but it was:\n$result"
+  fi
+}
+
+test_run_shell_error_outputs_parsing_argument_error_with_disabled_validation() {
+  assertErrorCode 1 -p examples/moon-base run --validate=false required-arg a
+  if [[ ! "$result" =~ "not <argument>=<value>" ]]; then
+    fail "Expected output to contain argument format error, but it was:\n$result"
+  fi
+  if [[ "$result" =~ "not supplied but is required" ]]; then
+    fail "Expected validation of required arguments to be skipped, but it was not:\n$result"
   fi
 }
 


### PR DESCRIPTION
Currently it is not possible to skip argument validation introduced in
c68e9b7230c7ec0cd25f761ccf27f61f7ca6ca98. This imposes an inconvinience when
using script overwrites to disable shared functionality.

# Example

A project uses plan 'foo' with a script 'bar' that requires argument 'baz' and
it is used in a shared pipeline, eg. Jenkinsfile, with the argument set
correctly.

If the project for some reason wants to opt-out of the script behaviour it can
add a local script of the same name 'bar' and define it as 'echo skipping...'.

With argument validation enabled in the pipeline, the project is no longer able
to build and maintainers of the plan can no longer add new required arguments to
the shared script as that would break any one opting out.

# Solution
As a solution to this, the 'validate' flag is added to the 'run' command. It is
intended to be used in shared invocations of scripts, eg. pipelines, and thus
gives the usual flexibility while still giving local development validation by
default.

The reasoning for this compromise is the validation has the most effect on local
development where developers might not know what arguments should be supplied or
or maybe they mistype their names. Developers working on pipelines take the hit,
but as that is a more slow moving target we accept that.