### PR TITLE
Remove arm64 from goarch

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,8 +1,14 @@
 builds:
-- env:
-  - CGO_ENABLED=0
-  ldflags:
-  - "-s -w -X github.com/lunarway/shuttle/cmd.version={{.Version}} -X github.com/lunarway/shuttle/cmd.commit={{.Commit}}"
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - 386
+    ldflags:
+      - "-s -w -X github.com/lunarway/shuttle/cmd.version={{.Version}} -X github.com/lunarway/shuttle/cmd.commit={{.Commit}}"
 
 archives:
 - id: archives


### PR DESCRIPTION
because it fails in goreleaser build and because the arm64 arch wasn't built in previous releases anyway