### PR TITLE
Remove os.Exit calls in pkg layer

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -97,8 +97,8 @@ Read more about shuttle at https://github.com/lunarway/shuttle`, version),
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		var uii = ui.Create()
-		uii.ExitWithErrorCode(1, "%s", err)
+		uii = ui.Create()
+		checkError(err)
 	}
 }
 
@@ -114,7 +114,7 @@ If none of above is used, then the argument will expect a full plan spec.`)
 	rootCmd.PersistentFlags().BoolVarP(&verboseFlag, "verbose", "v", false, "Print verbose output")
 }
 
-func getProjectContext() config.ShuttleProjectContext {
+func getProjectContext() (config.ShuttleProjectContext, error) {
 	dir, err := os.Getwd()
 	if err != nil {
 		log.Fatal(err)
@@ -136,6 +136,9 @@ func getProjectContext() config.ShuttleProjectContext {
 	}
 
 	var c config.ShuttleProjectContext
-	c.Setup(fullProjectPath, uii, clean, skipGitPlanPulling, plan)
-	return c
+	_, err = c.Setup(fullProjectPath, uii, clean, skipGitPlanPulling, plan)
+	if err != nil {
+		return config.ShuttleProjectContext{}, err
+	}
+	return c, nil
 }

--- a/cmd/error.go
+++ b/cmd/error.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+
+	shuttleerrors "github.com/lunarway/shuttle/pkg/errors"
+)
+
+func checkError(err error) {
+	if err == nil {
+		return
+	}
+	var exitCode *shuttleerrors.ExitCode
+	if errors.As(err, &exitCode) {
+		uii.Errorln("shuttle failed\n%s", exitCode.Message)
+		os.Exit(exitCode.Code)
+	}
+	uii.Errorln("shuttle failed\nError: %s", err)
+	os.Exit(1)
+}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -7,6 +7,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	"github.com/lunarway/shuttle/pkg/errors"
 	"github.com/lunarway/shuttle/pkg/templates"
 	"github.com/lunarway/shuttle/pkg/ui"
 
@@ -26,7 +27,8 @@ var getCmd = &cobra.Command{
 	//Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		uii = uii.SetContext(ui.LevelError)
-		context := getProjectContext()
+		context, err := getProjectContext()
+		checkError(err)
 		path := args[0]
 		var templ string
 		if getFlagTemplate != "" {
@@ -35,7 +37,7 @@ var getCmd = &cobra.Command{
 		value := templates.TmplGet(path, context.Config.Variables)
 		if templ != "" {
 			err := ui.Template(os.Stdout, "get", templ, value)
-			context.UI.CheckIfError(err)
+			checkError(err)
 			return
 		}
 		switch value.(type) {
@@ -44,7 +46,7 @@ var getCmd = &cobra.Command{
 		default:
 			x, err := yaml.Marshal(value)
 			if err != nil {
-				uii.ExitWithErrorCode(9, "Could not yaml encoded %s\nError: %s", value, err)
+				checkError(errors.NewExitCode(9, "Could not yaml encode value '%s'\nError: %s", value, err))
 			}
 			fmt.Print(strings.TrimRight(string(x), "\n"))
 		}

--- a/cmd/git-plan.go
+++ b/cmd/git-plan.go
@@ -13,7 +13,8 @@ var (
 		Short: "Run a git command for the plan",
 		Run: func(cmd *cobra.Command, args []string) {
 			skipGitPlanPulling = true
-			context := getProjectContext()
+			context, err := getProjectContext()
+			checkError(err)
 			git.RunGitPlanCommand(strings.Join(args, " "), context.LocalPlanPath, context.UI)
 		},
 	}

--- a/cmd/has.go
+++ b/cmd/has.go
@@ -20,7 +20,9 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			uii = uii.SetContext(ui.LevelSilent)
 
-			context := getProjectContext()
+			context, err := getProjectContext()
+			checkError(err)
+
 			variable := args[0]
 
 			var found bool

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -29,18 +29,20 @@ var lsCmd = &cobra.Command{
 	Use:   "ls [command]",
 	Short: "List possible commands",
 	Run: func(cmd *cobra.Command, args []string) {
-		context := getProjectContext()
+		context, err := getProjectContext()
+		checkError(err)
+
 		var templ string
 		if lsFlagTemplate != "" {
 			templ = lsFlagTemplate
 		} else {
 			templ = lsDefaultTempl
 		}
-		err := ui.Template(os.Stdout, "ls", templ, templData{
+		err = ui.Template(os.Stdout, "ls", templ, templData{
 			Scripts: context.Scripts,
 			Max:     calculateRightPadForKeys(context.Scripts),
 		})
-		context.UI.CheckIfError(err)
+		checkError(err)
 	},
 }
 

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -44,21 +44,23 @@ Available fields are:
 			TempDirectoryPath string
 		}
 		uii = uii.SetUserLevel(ui.LevelError)
-		context := getProjectContext()
+		context, err := getProjectContext()
+		checkError(err)
+
 		var templ string
 		if planFlagTemplate != "" {
 			templ = planFlagTemplate
 		} else {
 			templ = planDefaultTempl
 		}
-		err := ui.Template(os.Stdout, "plan", templ, templData{
+		err = ui.Template(os.Stdout, "plan", templ, templData{
 			Plan:              context.Config.Plan,
 			PlanRaw:           context.Config.PlanRaw,
 			LocalPlanPath:     context.LocalPlanPath,
 			ProjectPath:       context.ProjectPath,
 			TempDirectoryPath: context.TempDirectoryPath,
 		})
-		context.UI.CheckIfError(err)
+		checkError(err)
 	},
 }
 

--- a/cmd/prepare.go
+++ b/cmd/prepare.go
@@ -10,7 +10,8 @@ var (
 		Short: "Load external resources",
 		Long:  `Load external resources as a preparation step, before starting to use shuttle`,
 		Run: func(cmd *cobra.Command, args []string) {
-			getProjectContext()
+			_, err := getProjectContext()
+			checkError(err)
 		},
 	}
 )

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -14,8 +14,11 @@ var runCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		var commandName = args[0]
-		context := getProjectContext()
-		executors.Execute(context, commandName, args[1:], validateArgs)
+		context, err := getProjectContext()
+		checkError(err)
+
+		err = executors.Execute(context, commandName, args[1:], validateArgs)
+		checkError(err)
 	},
 }
 
@@ -31,12 +34,11 @@ func init() {
 			runCmd.Usage()
 			return
 		}
-		context := getProjectContext()
-		err := executors.Help(context.Scripts, scripts[0], os.Stdout, flagTemplate)
-		if err != nil {
-			context.UI.ExitWithError(err.Error())
-			return
-		}
+		context, err := getProjectContext()
+		checkError(err)
+
+		err = executors.Help(context.Scripts, scripts[0], os.Stdout, flagTemplate)
+		checkError(err)
 	})
 	runCmd.Flags().StringVar(&flagTemplate, "template", "", "Template string to use. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].")
 	runCmd.Flags().BoolVar(&validateArgs, "validate", true, "Validate arguments against script definition in plan and exit with 1 on unknown or missing arguments")

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -28,7 +28,8 @@ var templateCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var templateName = args[0]
-		projectContext := getProjectContext()
+		projectContext, err := getProjectContext()
+		checkError(err)
 
 		namedArgs := map[string]string{}
 		for _, arg := range args[1:] {

--- a/pkg/config/shuttleconfig.go
+++ b/pkg/config/shuttleconfig.go
@@ -1,10 +1,12 @@
 package config
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
 
+	"github.com/lunarway/shuttle/pkg/errors"
 	"github.com/lunarway/shuttle/pkg/ui"
 	"gopkg.in/yaml.v2"
 )
@@ -33,20 +35,32 @@ type ShuttleProjectContext struct {
 }
 
 // Setup the ShuttleProjectContext for a specific path
-func (c *ShuttleProjectContext) Setup(projectPath string, uii ui.UI, clean bool, skipGitPlanPulling bool, planArgument string) *ShuttleProjectContext {
-	c.Config.getConf(uii, projectPath)
+func (c *ShuttleProjectContext) Setup(projectPath string, uii ui.UI, clean bool, skipGitPlanPulling bool, planArgument string) (*ShuttleProjectContext, error) {
+	_, err := c.Config.getConf(uii, projectPath)
+	if err != nil {
+		return nil, err
+	}
 	c.UI = uii
 	c.ProjectPath = projectPath
 	c.LocalShuttleDirectoryPath = path.Join(c.ProjectPath, ".shuttle")
 
 	if clean {
-		os.RemoveAll(c.LocalShuttleDirectoryPath)
 		uii.Infoln("Cleaning %s", c.LocalShuttleDirectoryPath)
+		err := os.RemoveAll(c.LocalShuttleDirectoryPath)
+		if err != nil {
+			return nil, fmt.Errorf("remove '%s': %w", c.LocalShuttleDirectoryPath, err)
+		}
 	}
-	os.MkdirAll(c.LocalShuttleDirectoryPath, os.ModePerm)
+	err = os.MkdirAll(c.LocalShuttleDirectoryPath, os.ModePerm)
+	if err != nil {
+		return nil, fmt.Errorf("create '%s' directory: %w", c.LocalShuttleDirectoryPath, err)
+	}
 
 	c.TempDirectoryPath = path.Join(c.LocalShuttleDirectoryPath, "temp")
-	c.LocalPlanPath = FetchPlan(c.Config.Plan, projectPath, c.LocalShuttleDirectoryPath, uii, skipGitPlanPulling, planArgument)
+	c.LocalPlanPath, err = FetchPlan(c.Config.Plan, projectPath, c.LocalShuttleDirectoryPath, uii, skipGitPlanPulling, planArgument)
+	if err != nil {
+		return nil, err
+	}
 	c.Plan.Load(c.LocalPlanPath)
 	c.Scripts = make(map[string]ShuttlePlanScript)
 	for scriptName, script := range c.Plan.Scripts {
@@ -55,22 +69,22 @@ func (c *ShuttleProjectContext) Setup(projectPath string, uii ui.UI, clean bool,
 	for scriptName, script := range c.Config.Scripts {
 		c.Scripts[scriptName] = script
 	}
-	return c
+	return c, nil
 }
 
 // getConf loads the ShuttleConfig from yaml file in the project path
-func (c *ShuttleConfig) getConf(uii ui.UI, projectPath string) *ShuttleConfig {
+func (c *ShuttleConfig) getConf(uii ui.UI, projectPath string) (*ShuttleConfig, error) {
 	var configPath = path.Join(projectPath, "shuttle.yaml")
 
 	//log.Printf("configpath: %s", configPath)
 
 	yamlFile, err := ioutil.ReadFile(configPath)
 	if err != nil {
-		uii.ExitWithErrorCode(2, "Failed to load shuttle configuration: %s\n\nMake sure you are in a project using shuttle and that a 'shuttle.yaml' file is available.", err)
+		return nil, errors.NewExitCode(2, "Failed to load shuttle configuration: %s\n\nMake sure you are in a project using shuttle and that a 'shuttle.yaml' file is available.", err)
 	}
 	err = yaml.Unmarshal(yamlFile, c)
 	if err != nil {
-		uii.ExitWithErrorCode(2, "Failed to parse shuttle configuration: %s\n\nMake sure your 'shuttle.yaml' is valid.", err)
+		return nil, errors.NewExitCode(2, "Failed to parse shuttle configuration: %s\n\nMake sure your 'shuttle.yaml' is valid.", err)
 	}
 
 	switch c.PlanRaw {
@@ -80,5 +94,5 @@ func (c *ShuttleConfig) getConf(uii ui.UI, projectPath string) *ShuttleConfig {
 		c.Plan = c.PlanRaw.(string)
 	}
 
-	return c
+	return c, nil
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,21 @@
+package errors
+
+import "fmt"
+
+// ExitCode is an error indicating a specific exit code is used upon exit of
+// shuttle.
+type ExitCode struct {
+	Code    int
+	Message string
+}
+
+func (e *ExitCode) Error() string {
+	return fmt.Sprintf("exit code %d - %s", e.Code, e.Message)
+}
+
+func NewExitCode(code int, format string, args ...interface{}) error {
+	return &ExitCode{
+		Code:    code,
+		Message: fmt.Sprintf(format, args...),
+	}
+}

--- a/pkg/executors/docker.go
+++ b/pkg/executors/docker.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Build builds the docker image from a shuttle plan
-func executeDocker(context ActionExecutionContext) {
+func executeDocker(context ActionExecutionContext) error {
 	dockerFilePath := path.Join(context.ScriptContext.Project.LocalPlanPath, context.Action.Dockerfile)
 	projectPath := context.ScriptContext.Project.ProjectPath
 	execCmd := exec.Command("docker", "build", "-f", dockerFilePath, projectPath)
@@ -37,6 +37,7 @@ func executeDocker(context ActionExecutionContext) {
 	if errStdout != nil || errStderr != nil {
 		log.Fatalf("failed to capture stdout or stderr\n")
 	}
+	return nil
 }
 
 func init() {

--- a/pkg/executors/shell.go
+++ b/pkg/executors/shell.go
@@ -6,12 +6,13 @@ import (
 	"path/filepath"
 
 	"github.com/lunarway/shuttle/pkg/config"
+	"github.com/lunarway/shuttle/pkg/errors"
 
 	go_cmd "github.com/go-cmd/cmd"
 )
 
 // Build builds the docker image from a shuttle plan
-func executeShell(context ActionExecutionContext) {
+func executeShell(context ActionExecutionContext) error {
 	//log.Printf("Exec: %s", context.Action.Shell)
 	//cmdAndArgs := strings.Split(s.Shell, " ")
 	//cmd := cmdAndArgs[0]
@@ -64,8 +65,9 @@ func executeShell(context ActionExecutionContext) {
 	<-doneChan
 
 	if status.Exit > 0 {
-		context.ScriptContext.Project.UI.ExitWithErrorCode(4, "Failed executing script `%s`: shell script `%s`\nExit code: %v", context.ScriptContext.ScriptName, context.Action.Shell, status.Exit)
+		return errors.NewExitCode(4, "Failed executing script `%s`: shell script `%s`\nExit code: %v", context.ScriptContext.ScriptName, context.Action.Shell, status.Exit)
 	}
+	return nil
 }
 
 func init() {

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -80,22 +80,3 @@ func (ui *UI) Errorln(format string, args ...interface{}) {
 		fmt.Fprintf(os.Stderr, "\x1b[31;1m%s\x1b[0m\n", fmt.Sprintf(format, args...))
 	}
 }
-
-// ExitWithError doc
-func (ui *UI) ExitWithError(format string, args ...interface{}) {
-	ui.ExitWithErrorCode(1, format, args...)
-}
-
-// ExitWithErrorCode doc
-func (ui *UI) ExitWithErrorCode(code int, format string, args ...interface{}) {
-	ui.Errorln("shuttle failed\n"+format, args...)
-	os.Exit(code)
-}
-
-// CheckIfError doc
-func (ui *UI) CheckIfError(err error) {
-	if err == nil {
-		return
-	}
-	ui.ExitWithError("error: %s", err)
-}

--- a/tests.sh
+++ b/tests.sh
@@ -157,7 +157,7 @@ test_run_shell_error_outputs_script_name() {
 }
 
 test_run_shell_error_outputs_missing_arg() {
-  assertErrorCode 1 -p examples/moon-base run required-arg
+  assertErrorCode 2 -p examples/moon-base run required-arg
   if [[ ! "$result" =~ "required-arg" ]]; then
     fail "Expected output to contain the script name 'required-arg', but it was:\n$result"
   fi
@@ -171,7 +171,7 @@ test_run_shell_error_outputs_missing_arg_disabled_validation() {
 }
 
 test_run_shell_error_outputs_parsing_argument_error_with_disabled_validation() {
-  assertErrorCode 1 -p examples/moon-base run --validate=false required-arg a
+  assertErrorCode 2 -p examples/moon-base run --validate=false required-arg a
   if [[ ! "$result" =~ "not <argument>=<value>" ]]; then
     fail "Expected output to contain argument format error, but it was:\n$result"
   fi
@@ -181,7 +181,7 @@ test_run_shell_error_outputs_parsing_argument_error_with_disabled_validation() {
 }
 
 test_run_shell_error_outputs_unknown_argument() {
-  assertErrorCode 1 -p examples/moon-base run required-arg a=baz foo=bar
+  assertErrorCode 2 -p examples/moon-base run required-arg a=baz foo=bar
   assertContains "'foo' unknown" "$result"
 }
 


### PR DESCRIPTION
Currently a UI instance is passed around to all parts of shuttle allowing layers
to report messages to the user. It also provides methods ExitWithError,
ExitWithErrorCode and CheckIfError which are fatal messages stopping shuttle
completely by calling os.Exit. This makes shuttle in it self hard to test and
provides unclear exit paths of the code.

This change contains multiple changes to fix above issues.

The methods from package ui are removed and instead a checkError function is
added to package cmd which is responsible for selecting an exit code based on
the error. This greatly improvoes maintainability of the code and makes it
easier to reason about any possible exit paths from code in packages of pkg/*.

Some dead code is removed from package pkg/config. An unused CheckIfError
function was laying around here and as this change moves functionality around
related to the nature of this one I figured it was worth removing now.

During the change I found a couple of bugs in the error reporting that is fixed
as well.

When using command 'run' with invalid arguments exit code 1 indicating a shuttle
failure is reported instead of 2 indicating bad user input.

If a plan cannot be fetched due to an unknown protocol a panic is thrown. It now
returns an ExitCode error indicating bad user input.

Errors around the .shuttle directory are now also detected and propagated
instead of silently ignored.