### PR TITLE
Add documentation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,24 @@ $ shuttle run build tag=v1
 * ...
 
 ## Documentation
-*Documentation is under development*
+
+Plan documentation can be inspected using the `shuttle documentation` command.
+
+When writing shuttle plans you can hint as to where to find documentation for the plan.
+Users of the plan will open the specified URL when requesting documentation.
+
+```yaml
+# plan.yaml
+documentation: https://docs.my-corp.com
+```
+
+If no specific `documentation` field is set in the plan it will be inferred from the plan reference.
+In below example shuttle will open `https://github.com/lunarway/shuttle-example-go-plan.git`
+
+```yaml
+# shuttle.yaml
+plan: git@github.com:lunarway/shuttle-example-go-plan.git
+```
 
 ### Git Plan
 When using a git plan a url should look like:

--- a/cmd/documentation.go
+++ b/cmd/documentation.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"github.com/lunarway/shuttle/pkg/browser"
+	"github.com/lunarway/shuttle/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var documentationCommand = &cobra.Command{
+	Use:     "documentation",
+	Aliases: []string{"docs"},
+	Short:   "Open documentation for the configured shuttle plan",
+	Long: `Open documentation for the configured shuttle plan.
+By default shuttle will try to open the plan's documentation in a web browser.
+
+If no docs are explicitly configured in the plan, the plan it self is opened.
+Usually this will target a hosted git repository, eg. GitHub README.
+
+The application to open the documentation is inferred from the operating system
+and respects the BROWSER environment variable.`,
+	Args: cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		context, err := getProjectContext()
+		checkError(err)
+
+		url, err := context.DocumentationURL()
+		checkError(err)
+		uii.Infoln("Documentation available at: %s", url)
+
+		browseCmd, err := browser.Command(url)
+		checkError(err)
+
+		err = browseCmd.Run()
+		if err != nil {
+			checkError(errors.NewExitCode(1, "Failed to open document reference: %v", err))
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(documentationCommand)
+}

--- a/examples/station-plan/plan.yaml
+++ b/examples/station-plan/plan.yaml
@@ -1,3 +1,4 @@
+documentation: https://github.com/lunarway/shuttle
 scripts:
   build:
     description: Build the docker image

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,10 @@ require (
 	github.com/Masterminds/semver v1.4.2 // indirect
 	github.com/Masterminds/sprig v2.16.0+incompatible
 	github.com/aokoli/goutils v1.0.1 // indirect
+	github.com/cli/safeexec v1.0.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-cmd/cmd v1.2.0
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.0.0 // indirect
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,12 +4,16 @@ github.com/Masterminds/sprig v2.16.0+incompatible h1:QZbMUPxRQ50EKAq3LFMnxddMu88
 github.com/Masterminds/sprig v2.16.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/aokoli/goutils v1.0.1 h1:7fpzNGoJ3VA8qcrm++XEE1QUe0mIwNeLa02Nwq7RDkg=
 github.com/aokoli/goutils v1.0.1/go.mod h1:SijmP0QR8LtwsmDs8Yii5Z/S4trXFGFC2oO5g9DP+DQ=
+github.com/cli/safeexec v1.0.0 h1:0VngyaIyqACHdcMNWfo6+KdUYnqEr2Sg+bSP1pdF+dI=
+github.com/cli/safeexec v1.0.0/go.mod h1:Z/D4tTN8Vs5gXYHDCbaM1S/anmEDnJb1iW0+EJ5zx3Q=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-cmd/cmd v1.2.0 h1:Aohz0ZG0nQbvT4z55Mh+fdegX48GSAXL3cSsbYxRfvI=
 github.com/go-cmd/cmd v1.2.0/go.mod h1:XgKkd0L6sv9WcYV0FS8RfG1RJCSTVHTsLeAD2pTgHt0=
 github.com/go-test/deep v1.0.5 h1:AKODKU3pDH1RzZzm6YZu77YWtEAq6uh1rLIAQlay2qc=
 github.com/go-test/deep v1.0.5/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/huandu/xstrings v1.2.0 h1:yPeWdRnmynF7p+lLYz0H2tthW9lqhMJrQV/U7yy4wX0=

--- a/pkg/browser/browser.go
+++ b/pkg/browser/browser.go
@@ -1,0 +1,77 @@
+package browser
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/cli/safeexec"
+	"github.com/google/shlex"
+)
+
+// This package is copied from github.com/cli/cli
+
+// Command returns an exec.Cmd instance respecting runtime.GOOS and $BROWSER
+// environment variable.
+func Command(url string) (*exec.Cmd, error) {
+	launcher := os.Getenv("BROWSER")
+	if launcher != "" {
+		return fromBrowserEnv(launcher, url)
+	}
+	return forOS(runtime.GOOS, url), nil
+}
+
+func forOS(goos, url string) *exec.Cmd {
+	exe := "open"
+	var args []string
+	switch goos {
+	case "darwin":
+		args = append(args, url)
+	case "windows":
+		exe, _ = lookPath("cmd")
+		r := strings.NewReplacer("&", "^&")
+		args = append(args, "/c", "start", r.Replace(url))
+	default:
+		exe = linuxExe()
+		args = append(args, url)
+	}
+
+	cmd := exec.Command(exe, args...)
+	cmd.Stderr = os.Stderr
+	return cmd
+}
+
+// fromBrowserEnv parses the BROWSER string based on shell splitting rules.
+func fromBrowserEnv(launcher, url string) (*exec.Cmd, error) {
+	args, err := shlex.Split(launcher)
+	if err != nil {
+		return nil, err
+	}
+
+	exe, err := lookPath(args[0])
+	if err != nil {
+		return nil, err
+	}
+
+	args = append(args, url)
+	cmd := exec.Command(exe, args[1:]...)
+	cmd.Stderr = os.Stderr
+	return cmd, nil
+}
+
+func linuxExe() string {
+	exe := "xdg-open"
+
+	_, err := lookPath(exe)
+	if err != nil {
+		_, err := lookPath("wslview")
+		if err == nil {
+			exe = "wslview"
+		}
+	}
+
+	return exe
+}
+
+var lookPath = safeexec.LookPath

--- a/pkg/browser/browser_test.go
+++ b/pkg/browser/browser_test.go
@@ -1,0 +1,78 @@
+package browser
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+// This package is copied from github.com/cli/cli
+
+func TestForOS(t *testing.T) {
+	type args struct {
+		goos string
+		url  string
+	}
+	tests := []struct {
+		name string
+		args args
+		exe  string
+		want []string
+	}{
+		{
+			name: "macOS",
+			args: args{
+				goos: "darwin",
+				url:  "https://example.com/path?a=1&b=2",
+			},
+			want: []string{"open", "https://example.com/path?a=1&b=2"},
+		},
+		{
+			name: "Linux",
+			args: args{
+				goos: "linux",
+				url:  "https://example.com/path?a=1&b=2",
+			},
+			exe:  "xdg-open",
+			want: []string{"xdg-open", "https://example.com/path?a=1&b=2"},
+		},
+		{
+			name: "WSL",
+			args: args{
+				goos: "linux",
+				url:  "https://example.com/path?a=1&b=2",
+			},
+			exe:  "wslview",
+			want: []string{"wslview", "https://example.com/path?a=1&b=2"},
+		},
+		{
+			name: "Windows",
+			args: args{
+				goos: "windows",
+				url:  "https://example.com/path?a=1&b=2&c=3",
+			},
+			exe:  "cmd",
+			want: []string{"cmd", "/c", "start", "https://example.com/path?a=1^&b=2^&c=3"},
+		},
+	}
+	for _, tt := range tests {
+		origLookPath := lookPath
+		lookPath = func(file string) (string, error) {
+			if file == tt.exe {
+				return file, nil
+			} else {
+				return "", errors.New("not found")
+			}
+		}
+		defer func() {
+			lookPath = origLookPath
+		}()
+
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := forOS(tt.args.goos, tt.args.url)
+			if !reflect.DeepEqual(cmd.Args, tt.want) {
+				t.Errorf("ForOS() = %v, want %v", cmd.Args, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/config/documentation.go
+++ b/pkg/config/documentation.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/lunarway/shuttle/pkg/errors"
+	"github.com/lunarway/shuttle/pkg/git"
+)
+
+// DocumentationURL returns a URL pointing to plan documentation if any is
+// available. Plan reference and plan documentation field is inspected and
+// parsed.
+func (p *ShuttleProjectContext) DocumentationURL() (string, error) {
+	var ref string
+	switch {
+	case p.Plan.Documentation != "":
+		ref = p.Plan.Documentation
+	case p.Config.Plan != "":
+		ref = p.Config.Plan
+	default:
+		return "", errors.NewExitCode(1, "Could not find any plan documentation")
+	}
+
+	switch {
+	case git.IsPlan(ref):
+		return normalizeGitPlan(git.ParsePlan(ref))
+	case isMatching("^(http|https)://", ref):
+		return ref, nil
+	case filepath.IsAbs(ref), strings.HasPrefix(ref, "./"), strings.HasPrefix(ref, "../"):
+		return "", errors.NewExitCode(2, "Local plan has no documentation")
+	default:
+		return "", errors.NewExitCode(1, "Could not detect protocol for plan '%s'", ref)
+	}
+}
+
+func normalizeGitPlan(p git.Plan) (string, error) {
+	switch p.Protocol {
+	case "https":
+		return fmt.Sprintf("%s://%s", p.Protocol, p.Repository), nil
+	case "ssh":
+		repoSlug := strings.TrimPrefix(p.Repository, fmt.Sprintf("%s:", p.Host))
+		return fmt.Sprintf("https://%s/%s", p.Host, repoSlug), nil
+	default:
+		// this should never happen as parsed git plans always has a protocol of ssh
+		// or https
+		return "", errors.NewExitCode(1, "Could not parse git plan reference")
+	}
+}

--- a/pkg/config/documentation.go
+++ b/pkg/config/documentation.go
@@ -26,7 +26,7 @@ func (p *ShuttleProjectContext) DocumentationURL() (string, error) {
 	switch {
 	case git.IsPlan(ref):
 		return normalizeGitPlan(git.ParsePlan(ref))
-	case isMatching("^(http|https)://", ref):
+	case isHTTPSPlan(ref):
 		return ref, nil
 	case filepath.IsAbs(ref), strings.HasPrefix(ref, "./"), strings.HasPrefix(ref, "../"):
 		return "", errors.NewExitCode(2, "Local plan has no documentation")

--- a/pkg/config/documentation_test.go
+++ b/pkg/config/documentation_test.go
@@ -32,7 +32,7 @@ func TestShuttleProjectContext_Documentation(t *testing.T) {
 			err:     errors.New("exit code 1 - Could not detect protocol for plan 'something-odd'"),
 		},
 		{
-			name:    "unknown git plan protocol",
+			name:    "unknown plan reference protocol",
 			planRef: "something-odd",
 			docsRef: "",
 			result:  "",

--- a/pkg/config/documentation_test.go
+++ b/pkg/config/documentation_test.go
@@ -1,0 +1,125 @@
+package config_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/lunarway/shuttle/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShuttleProjectContext_Documentation(t *testing.T) {
+	tt := []struct {
+		name    string
+		planRef string
+		docsRef string
+
+		result string
+		err    error
+	}{
+		{
+			name:    "empty context",
+			planRef: "",
+			docsRef: "",
+			result:  "",
+			err:     errors.New("exit code 1 - Could not find any plan documentation"),
+		},
+		{
+			name:    "unknown plan protocol",
+			planRef: "something-odd",
+			docsRef: "",
+			result:  "",
+			err:     errors.New("exit code 1 - Could not detect protocol for plan 'something-odd'"),
+		},
+		{
+			name:    "unknown git plan protocol",
+			planRef: "something-odd",
+			docsRef: "",
+			result:  "",
+			err:     errors.New("exit code 1 - Could not detect protocol for plan 'something-odd'"),
+		},
+		{
+			name:    "explicit HTTP docs",
+			planRef: "",
+			docsRef: "http://github.com/lunarway/shuttle",
+			result:  "http://github.com/lunarway/shuttle",
+			err:     nil,
+		},
+		{
+			name:    "explicit HTTPS docs",
+			planRef: "",
+			docsRef: "https://github.com/lunarway/shuttle",
+			result:  "https://github.com/lunarway/shuttle",
+			err:     nil,
+		},
+		{
+			name:    "no explicit docs and git plan ssh reference",
+			planRef: "git://git@github.com:lunarway/shuttle-example-go-plan.git",
+			docsRef: "",
+			result:  "https://github.com/lunarway/shuttle-example-go-plan.git",
+			err:     nil,
+		},
+		{
+			name:    "no explicit docs and git plan http reference",
+			planRef: "http://github.com/lunarway/shuttle-example-go-plan.git",
+			docsRef: "",
+			result:  "http://github.com/lunarway/shuttle-example-go-plan.git",
+			err:     nil,
+		},
+		{
+			name:    "no explicit docs and git plan https reference",
+			planRef: "https://github.com/lunarway/shuttle-example-go-plan.git",
+			docsRef: "",
+			result:  "https://github.com/lunarway/shuttle-example-go-plan.git",
+			err:     nil,
+		},
+		{
+			name:    "no explicit docs and git plan has branch reference",
+			planRef: "https://github.com/lunarway/shuttle-example-go-plan.git#branch",
+			docsRef: "",
+			result:  "https://github.com/lunarway/shuttle-example-go-plan.git",
+			err:     nil,
+		},
+		{
+			name:    "absolute local file path",
+			planRef: "/plan",
+			docsRef: "",
+			result:  "",
+			err:     errors.New("exit code 2 - Local plan has no documentation"),
+		},
+		{
+			name:    "local file path",
+			planRef: "./plan",
+			docsRef: "",
+			result:  "",
+			err:     errors.New("exit code 2 - Local plan has no documentation"),
+		},
+		{
+			name:    "local file path in parent path",
+			planRef: "../plan",
+			docsRef: "",
+			result:  "",
+			err:     errors.New("exit code 2 - Local plan has no documentation"),
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			p := config.ShuttleProjectContext{
+				Config: config.ShuttleConfig{
+					Plan: tc.planRef,
+				},
+				Plan: config.ShuttlePlanConfiguration{
+					Documentation: tc.docsRef,
+				},
+			}
+			result, err := p.DocumentationURL()
+
+			if tc.err != nil {
+				assert.EqualError(t, err, tc.err.Error(), "error not as expected")
+			} else {
+				assert.NoError(t, err, "unexpected error")
+			}
+			assert.Equal(t, tc.result, result, "result not as expected")
+		})
+	}
+}

--- a/pkg/config/planargument.go
+++ b/pkg/config/planargument.go
@@ -1,10 +1,11 @@
 package config
 
 import (
-	"github.com/lunarway/shuttle/pkg/git"
 	"os"
 	"path"
 	"strings"
+
+	"github.com/lunarway/shuttle/pkg/git"
 )
 
 func isPlanArgumentAFilePlan(planArgument string) bool {
@@ -12,7 +13,7 @@ func isPlanArgumentAFilePlan(planArgument string) bool {
 }
 
 func isPlanArgumentAPlan(planArgument string) bool {
-	return planArgument != "" && (git.IsGitPlan(planArgument) || isPlanArgumentAFilePlan(planArgument))
+	return planArgument != "" && (git.IsPlan(planArgument) || isPlanArgumentAFilePlan(planArgument))
 }
 
 func getPlanFromPlanArgument(planArgument string) string {

--- a/pkg/config/shuttleplan.go
+++ b/pkg/config/shuttleplan.go
@@ -93,7 +93,7 @@ func FetchPlan(plan string, projectPath string, localShuttleDirectoryPath string
 	case git.IsPlan(plan):
 		uii.Verboseln("Using git plan at '%s'", plan)
 		return git.GetGitPlan(plan, localShuttleDirectoryPath, uii, skipGitPlanPulling, planArgument)
-	case isMatching("^http://|^https://", plan):
+	case isHTTPSPlan(plan):
 		panic(fmt.Sprintf("Plan '%v' is not valid: non-git http/https is not supported yet", plan))
 	case isFilePath(plan, true):
 		uii.Verboseln("Using local plan at '%s'", plan)
@@ -110,10 +110,8 @@ func isFilePath(path string, matchOnlyAbs bool) bool {
 	return filepath.IsAbs(path) == matchOnlyAbs
 }
 
-func isMatching(r string, content string) bool {
-	match, err := regexp.MatchString(r, content)
-	if err != nil {
-		panic(err)
-	}
-	return match
+var httpsRegexp = regexp.MustCompile("^(http|https)://")
+
+func isHTTPSPlan(plan string) bool {
+	return httpsRegexp.MatchString(plan)
 }

--- a/pkg/config/shuttleplan.go
+++ b/pkg/config/shuttleplan.go
@@ -49,7 +49,8 @@ type ShuttleAction struct {
 
 // ShuttlePlanConfiguration is a ShuttlePlan sub-element
 type ShuttlePlanConfiguration struct {
-	Scripts map[string]ShuttlePlanScript `yaml:"scripts"`
+	Documentation string                       `yaml:"documentation"`
+	Scripts       map[string]ShuttlePlanScript `yaml:"scripts"`
 }
 
 // ShuttlePlan struct describes a plan
@@ -89,7 +90,7 @@ func FetchPlan(plan string, projectPath string, localShuttleDirectoryPath string
 	case plan == "":
 		uii.Verboseln("Using no plan")
 		return "", nil
-	case git.IsGitPlan(plan):
+	case git.IsPlan(plan):
 		uii.Verboseln("Using git plan at '%s'", plan)
 		return git.GetGitPlan(plan, localShuttleDirectoryPath, uii, skipGitPlanPulling, planArgument)
 	case isMatching("^http://|^https://", plan):

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -187,14 +187,6 @@ func RunGitPlanCommand(command string, plan string, uii ui.UI) {
 	}
 }
 
-func isMatching(r string, content string) bool {
-	match, err := regexp.MatchString(r, content)
-	if err != nil {
-		panic(err)
-	}
-	return match
-}
-
 func checkIfError(err error) {
 	if err == nil {
 		return

--- a/pkg/git/parse_test.go
+++ b/pkg/git/parse_test.go
@@ -7,59 +7,59 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseGitPlan(t *testing.T) {
+func TestParsePlan(t *testing.T) {
 	tt := []struct {
 		input  string
-		output gitPlan
+		output Plan
 	}{
 		{
 			input: "git://git@github.com:lunarway/some-plan.git#some-branch",
-			output: gitPlan{
-				isGitPlan:  true,
-				protocol:   "ssh",
-				user:       "git",
-				host:       "github.com",
-				repository: "github.com:lunarway/some-plan.git",
-				head:       "some-branch",
+			output: Plan{
+				IsGitPlan:  true,
+				Protocol:   "ssh",
+				User:       "git",
+				Host:       "github.com",
+				Repository: "github.com:lunarway/some-plan.git",
+				Head:       "some-branch",
 			},
 		},
 		{
 			input: "git://git@github.com:lunarway/some-plan.git",
-			output: gitPlan{
-				isGitPlan:  true,
-				protocol:   "ssh",
-				user:       "git",
-				host:       "github.com",
-				repository: "github.com:lunarway/some-plan.git",
-				head:       "master",
+			output: Plan{
+				IsGitPlan:  true,
+				Protocol:   "ssh",
+				User:       "git",
+				Host:       "github.com",
+				Repository: "github.com:lunarway/some-plan.git",
+				Head:       "master",
 			},
 		},
 		{
 			input: "https://github.com/lunarway/some-plan.git#some-branch",
-			output: gitPlan{
-				isGitPlan:  true,
-				protocol:   "https",
-				user:       "",
-				host:       "",
-				repository: "github.com/lunarway/some-plan.git",
-				head:       "some-branch",
+			output: Plan{
+				IsGitPlan:  true,
+				Protocol:   "https",
+				User:       "",
+				Host:       "",
+				Repository: "github.com/lunarway/some-plan.git",
+				Head:       "some-branch",
 			},
 		},
 		{
 			input: "https://github.com/lunarway/some-plan.git",
-			output: gitPlan{
-				isGitPlan:  true,
-				protocol:   "https",
-				user:       "",
-				host:       "",
-				repository: "github.com/lunarway/some-plan.git",
-				head:       "master",
+			output: Plan{
+				IsGitPlan:  true,
+				Protocol:   "https",
+				User:       "",
+				Host:       "",
+				Repository: "github.com/lunarway/some-plan.git",
+				Head:       "master",
 			},
 		},
 	}
 	for _, tc := range tt {
 		t.Run(fmt.Sprintf("can parse %s", tc.input), func(t *testing.T) {
-			output := parseGitPlan(tc.input)
+			output := ParsePlan(tc.input)
 
 			assert.Equal(t, tc.output, output, "output does not match the expected")
 		})


### PR DESCRIPTION
This change set contains a new documentation command.

    $ shuttle docs --project examples/moon-base
    Documentation available at: https://github.com/lunarway/shuttle

It will open up documentation for the used shuttle plan. If a plan specifies a
top level "documentation" field, that is used. If not available the plan
reference is parsed and a URL is inferred.

The command will open the found URL respecting the BROWSER environment variable
and falling back to OS specific ways of "opening" URLs.

Closes #49 as the issue was minded on easy access to the plan's documentation.
Also closes #7 as we cannot rely on docs only being available in a plans
README.md. As an example, in Lunar we document plans with [MkDocs](https://www.mkdocs.org/) and publish
them to [Backstage.io](https://backstage.io).