### PR TITLE
Parse shuttle.yaml and plan.yaml strictly

### DIFF
--- a/pkg/config/shuttleconfig_test.go
+++ b/pkg/config/shuttleconfig_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShuttleConfig_getConf(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  string
+		err    error
+		config ShuttleConfig
+	}{
+		{
+			name:  "empty path",
+			input: "",
+		},
+		{
+			name:  "unknown field",
+			input: "testdata/unknown_field",
+			err:   errors.New("exit code 2 - Failed to parse shuttle configuration: yaml: unmarshal errors:\n  line 1: field nothing not found in type config.ShuttleConfig\n\nMake sure your 'shuttle.yaml' is valid."),
+		},
+		{
+			name:  "unknown file",
+			input: "testdata/unknown_file",
+			err:   errors.New("exit code 2 - Failed to load shuttle configuration: open testdata/unknown_file/shuttle.yaml: no such file or directory\n\nMake sure you are in a project using shuttle and that a 'shuttle.yaml' file is available."),
+		},
+		{
+			name:  "valid",
+			input: "testdata/valid",
+			err:   nil,
+			config: ShuttleConfig{
+				Plan:    ".",
+				PlanRaw: ".",
+				Variables: map[string]interface{}{
+					"squad": "nasa",
+				},
+				Scripts: map[string]ShuttlePlanScript{
+					"shout": {
+						Description: "Shout hello",
+						Actions: []ShuttleAction{
+							{
+								Shell: `echo "HELLO WORLD"`,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &ShuttleConfig{}
+			var err error
+			c, err = c.getConf(tc.input)
+
+			if tc.err != nil {
+				assert.EqualError(t, err, tc.err.Error(), "error not as expected")
+			} else {
+				assert.NoError(t, err, "unexpected error")
+			}
+			assert.Equal(t, tc.config, *c, "config not as expected")
+		})
+	}
+}

--- a/pkg/config/shuttleplan.go
+++ b/pkg/config/shuttleplan.go
@@ -2,8 +2,7 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
-	"log"
+	"os"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -60,22 +59,27 @@ type ShuttlePlan struct {
 }
 
 // Load loads a plan from project path and shuttle config
-func (p *ShuttlePlanConfiguration) Load(planPath string) *ShuttlePlanConfiguration {
+func (p *ShuttlePlanConfiguration) Load(planPath string) (*ShuttlePlanConfiguration, error) {
 	if planPath == "" {
-		return p
-	}
-	var configPath = path.Join(planPath, "plan.yaml")
-	//log.Printf("configpath: %s", configPath)
-	yamlFile, err := ioutil.ReadFile(configPath)
-	if err != nil {
-		log.Printf("yamlFile.Get err   #%v ", err)
-	}
-	err = yaml.Unmarshal(yamlFile, p)
-	if err != nil {
-		log.Fatalf("Unmarshal: %v", err)
+		return p, nil
 	}
 
-	return p
+	configPath := path.Join(planPath, "plan.yaml")
+
+	file, err := os.Open(configPath)
+	if err != nil {
+		return p, errors.NewExitCode(2, "Failed to open plan configuration: %s\n\nMake sure you are in a project using shuttle and that a 'shuttle.yaml' file is available.", err)
+	}
+	defer file.Close()
+
+	decoder := yaml.NewDecoder(file)
+	decoder.SetStrict(true)
+	err = decoder.Decode(p)
+	if err != nil {
+		return p, errors.NewExitCode(1, "Failed to load plan configuration: %s\n\nThis is likely an issue with the referenced plan. Please, contact the plan maintainers.", err)
+	}
+
+	return p, nil
 }
 
 // FetchPlan so it exists locally and return path to that plan

--- a/pkg/config/shuttleplan_test.go
+++ b/pkg/config/shuttleplan_test.go
@@ -1,0 +1,63 @@
+package config
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShuttlePlanConfiguration_Load(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  string
+		err    error
+		config ShuttlePlanConfiguration
+	}{
+		{
+			name:  "empty path",
+			input: "",
+		},
+		{
+			name:  "unknown field",
+			input: "testdata/unknown_field",
+			err:   errors.New("exit code 1 - Failed to load plan configuration: yaml: unmarshal errors:\n  line 1: field unknown not found in type config.ShuttlePlanConfiguration\n\nThis is likely an issue with the referenced plan. Please, contact the plan maintainers."),
+		},
+		{
+			name:  "unknown file",
+			input: "testdata/unknown_file",
+			err:   errors.New("exit code 2 - Failed to open plan configuration: open testdata/unknown_file/plan.yaml: no such file or directory\n\nMake sure you are in a project using shuttle and that a 'shuttle.yaml' file is available."),
+		},
+		{
+			name:  "valid",
+			input: "testdata/valid",
+			err:   nil,
+			config: ShuttlePlanConfiguration{
+				Scripts: map[string]ShuttlePlanScript{
+					"hello": {
+						Description: "Say hello",
+						Actions: []ShuttleAction{
+							{
+								Shell: `echo "Hello world"`,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &ShuttlePlanConfiguration{}
+			var err error
+			c, err = c.Load(tc.input)
+
+			if tc.err != nil {
+				assert.EqualError(t, err, tc.err.Error(), "error not as expected")
+			} else {
+				assert.NoError(t, err, "unexpected error")
+			}
+			assert.Equal(t, tc.config, *c, "config not as expected")
+		})
+	}
+}

--- a/pkg/config/testdata/unknown_field/plan.yaml
+++ b/pkg/config/testdata/unknown_field/plan.yaml
@@ -1,0 +1,1 @@
+unknown: field

--- a/pkg/config/testdata/unknown_field/shuttle.yaml
+++ b/pkg/config/testdata/unknown_field/shuttle.yaml
@@ -1,0 +1,1 @@
+nothing: important

--- a/pkg/config/testdata/valid/plan.yaml
+++ b/pkg/config/testdata/valid/plan.yaml
@@ -1,0 +1,5 @@
+scripts:
+  hello:
+    description: Say hello
+    actions:
+    - shell: echo "Hello world"

--- a/pkg/config/testdata/valid/shuttle.yaml
+++ b/pkg/config/testdata/valid/shuttle.yaml
@@ -1,0 +1,8 @@
+plan: .
+vars:
+  squad: nasa
+scripts:
+  shout:
+    description: Shout hello
+    actions:
+    - shell: echo "HELLO WORLD"


### PR DESCRIPTION
Currently we silently ignore unknown fields in shuttle.yaml and plan.yaml. This
can lead to odd behaviour and hard to find bugs from typos.

This change adds strict parsing of shuttle.yaml and plan.yaml failing commands
if any unexpected fields are found.

Closes #3.