### PR TITLE
Upgrade to Go 1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-- "1.15.x"
+- "1.16.x"
 
 script: |
   echo "Build shuttle" &&

--- a/examples/custom-template.tmpl
+++ b/examples/custom-template.tmpl
@@ -1,5 +1,10 @@
 # Custom docker file template not located inside a project
-FROM golang:{{ get "GO_VERSION" .Args }}-alpine as builder
+{{-
+  $imageTag :=
+    get "GO_VERSION" .Args |
+    printf "%s-alpine"
+}}
+FROM golang:{{ $imageTag }} as builder
 
 LABEL custom=field
 

--- a/tests.sh
+++ b/tests.sh
@@ -186,7 +186,7 @@ test_run_shell_error_outputs_unknown_argument() {
 }
 
 test_template_local_path() {
-  assertErrorCode 0 -p examples/moon-base template ../custom-template.tmpl -o Dockerfile-custom
+  assertErrorCode 0 -p examples/moon-base template ../custom-template.tmpl -o Dockerfile-custom GO_VERSION=1.16
 }
 
 test_template_local_path_alternate_delims() {


### PR DESCRIPTION
This change upgrades the Go toolchain to 1.16.x.

A relevant change is the support for newlines in template actions. Chained
actions, eg `"some value" | printf "%s-suffix"` can now span multiple lines
inside the `{{}}` action delimiters.