### PR TITLE
Fix bug in plan configuration decoding

### DIFF
--- a/pkg/config/shuttleplan.go
+++ b/pkg/config/shuttleplan.go
@@ -48,6 +48,7 @@ type ShuttleAction struct {
 
 // ShuttlePlanConfiguration is a ShuttlePlan sub-element
 type ShuttlePlanConfiguration struct {
+	Vars          map[string]interface{}       `yaml:"vars"`
 	Documentation string                       `yaml:"documentation"`
 	Scripts       map[string]ShuttlePlanScript `yaml:"scripts"`
 }
@@ -77,7 +78,7 @@ func (p *ShuttlePlanConfiguration) Load(planPath string) (*ShuttlePlanConfigurat
 	decoder.SetStrict(true)
 	err = decoder.Decode(p)
 	if err != nil {
-		return p, errors.NewExitCode(1, "Failed to load plan configuration: %s\n\nThis is likely an issue with the referenced plan. Please, contact the plan maintainers.", err)
+		return p, errors.NewExitCode(1, "Failed to load plan configuration from '%s': %s\n\nThis is likely an issue with the referenced plan. Please, contact the plan maintainers.", configPath, err)
 	}
 
 	return p, nil

--- a/pkg/config/shuttleplan_test.go
+++ b/pkg/config/shuttleplan_test.go
@@ -21,7 +21,7 @@ func TestShuttlePlanConfiguration_Load(t *testing.T) {
 		{
 			name:  "unknown field",
 			input: "testdata/unknown_field",
-			err:   errors.New("exit code 1 - Failed to load plan configuration: yaml: unmarshal errors:\n  line 1: field unknown not found in type config.ShuttlePlanConfiguration\n\nThis is likely an issue with the referenced plan. Please, contact the plan maintainers."),
+			err:   errors.New("exit code 1 - Failed to load plan configuration from 'testdata/unknown_field/plan.yaml': yaml: unmarshal errors:\n  line 1: field unknown not found in type config.ShuttlePlanConfiguration\n\nThis is likely an issue with the referenced plan. Please, contact the plan maintainers."),
 		},
 		{
 			name:  "unknown file",
@@ -33,6 +33,9 @@ func TestShuttlePlanConfiguration_Load(t *testing.T) {
 			input: "testdata/valid",
 			err:   nil,
 			config: ShuttlePlanConfiguration{
+				Vars: map[string]interface{}{
+					"shared": "var",
+				},
 				Scripts: map[string]ShuttlePlanScript{
 					"hello": {
 						Description: "Say hello",

--- a/pkg/config/testdata/valid/plan.yaml
+++ b/pkg/config/testdata/valid/plan.yaml
@@ -1,3 +1,5 @@
+vars:
+  shared: var
 scripts:
   hello:
     description: Say hello


### PR DESCRIPTION
Currently shuttle cannot use plans with shared variables set in the "vars"
section. This is a bug introduced in 89c04a2676d1e851ef9dcf987ed95c0f6b31d917 (#64) where we enabled strict parsing.

This change allows the usage of "vars" in plan.yaml configuration files.