### PR TITLE
Support shuttle commands from sub directories

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -121,6 +121,8 @@ func getProjectContext() (config.ShuttleProjectContext, error) {
 		os.Exit(1)
 	}
 
+	projectFlagSet := rootCmd.Flags().Changed("project")
+
 	var fullProjectPath string
 	if path.IsAbs(projectPath) {
 		fullProjectPath = projectPath
@@ -136,7 +138,7 @@ func getProjectContext() (config.ShuttleProjectContext, error) {
 	}
 
 	var c config.ShuttleProjectContext
-	_, err = c.Setup(fullProjectPath, uii, clean, skipGitPlanPulling, plan)
+	_, err = c.Setup(fullProjectPath, uii, clean, skipGitPlanPulling, plan, projectFlagSet)
 	if err != nil {
 		return config.ShuttleProjectContext{}, err
 	}

--- a/examples/stepping-stone/shuttle.yaml
+++ b/examples/stepping-stone/shuttle.yaml
@@ -1,0 +1,6 @@
+plan: false
+scripts:
+  say:
+    description: Write output
+    actions:
+      - shell: echo "$project"

--- a/pkg/config/shuttleconfig.go
+++ b/pkg/config/shuttleconfig.go
@@ -105,6 +105,8 @@ func (c *ShuttleConfig) getConf(projectPath string, strictConfigLookup bool) (st
 	return path.Dir(file.Name()), nil
 }
 
+var errShuttleFileNotFound = errors.New("shuttle.yaml file not found")
+
 func locateShuttleConfigurationFile(startPath string, strictConfigLookup bool) (*os.File, error) {
 	var err error
 	for {
@@ -115,11 +117,12 @@ func locateShuttleConfigurationFile(startPath string, strictConfigLookup bool) (
 		if err != nil {
 			if os.IsNotExist(err) {
 				if startPath == "" || startPath == "/" {
-					err = errors.New("shuttle.yaml file not found")
+					err = errShuttleFileNotFound
 					break
 				}
 
 				if strictConfigLookup {
+					err = errShuttleFileNotFound
 					break
 				}
 

--- a/pkg/config/shuttleconfig.go
+++ b/pkg/config/shuttleconfig.go
@@ -1,11 +1,13 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
+	"strings"
 
-	"github.com/lunarway/shuttle/pkg/errors"
+	shuttleerrors "github.com/lunarway/shuttle/pkg/errors"
 	"github.com/lunarway/shuttle/pkg/ui"
 	"gopkg.in/yaml.v2"
 )
@@ -35,7 +37,7 @@ type ShuttleProjectContext struct {
 
 // Setup the ShuttleProjectContext for a specific path
 func (c *ShuttleProjectContext) Setup(projectPath string, uii ui.UI, clean bool, skipGitPlanPulling bool, planArgument string) (*ShuttleProjectContext, error) {
-	_, err := c.Config.getConf(projectPath)
+	projectPath, err := c.Config.getConf(projectPath)
 	if err != nil {
 		return nil, err
 	}
@@ -75,16 +77,14 @@ func (c *ShuttleProjectContext) Setup(projectPath string, uii ui.UI, clean bool,
 }
 
 // getConf loads the ShuttleConfig from yaml file in the project path
-func (c *ShuttleConfig) getConf(projectPath string) (*ShuttleConfig, error) {
+func (c *ShuttleConfig) getConf(projectPath string) (string, error) {
 	if projectPath == "" {
-		return c, nil
+		return projectPath, nil
 	}
 
-	configPath := path.Join(projectPath, "shuttle.yaml")
-
-	file, err := os.Open(configPath)
+	file, err := locateShuttleConfigurationFile(projectPath)
 	if err != nil {
-		return c, errors.NewExitCode(2, "Failed to load shuttle configuration: %s\n\nMake sure you are in a project using shuttle and that a 'shuttle.yaml' file is available.", err)
+		return "", shuttleerrors.NewExitCode(2, "Failed to load shuttle configuration: %s\n\nMake sure you are in a project using shuttle and that a 'shuttle.yaml' file is available.", err)
 	}
 	defer file.Close()
 
@@ -92,7 +92,7 @@ func (c *ShuttleConfig) getConf(projectPath string) (*ShuttleConfig, error) {
 	decoder.SetStrict(true)
 	err = decoder.Decode(c)
 	if err != nil {
-		return c, errors.NewExitCode(2, "Failed to parse shuttle configuration: %s\n\nMake sure your 'shuttle.yaml' is valid.", err)
+		return "", shuttleerrors.NewExitCode(2, "Failed to parse shuttle configuration: %s\n\nMake sure your 'shuttle.yaml' is valid.", err)
 	}
 
 	switch c.PlanRaw {
@@ -101,6 +101,46 @@ func (c *ShuttleConfig) getConf(projectPath string) (*ShuttleConfig, error) {
 	default:
 		c.Plan = c.PlanRaw.(string)
 	}
+	// return the path where the shuttle.yaml file was found
+	return path.Dir(file.Name()), nil
+}
 
-	return c, nil
+func locateShuttleConfigurationFile(startPath string) (*os.File, error) {
+	var err error
+	for {
+		configPath := path.Join(startPath, "shuttle.yaml")
+
+		var file *os.File
+		file, err = os.Open(configPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				if startPath == "" || startPath == "/" {
+					err = errors.New("shuttle.yaml file not found")
+					break
+				}
+
+				startPath = removeLastDirectory(startPath)
+				continue
+			}
+			break
+		}
+
+		return file, nil
+	}
+
+	return nil, err
+}
+
+func removeLastDirectory(projectPath string) string {
+	parts := strings.Split(projectPath, "/")
+
+	newProjectPath := strings.Join(parts[0:len(parts)-1], "/")
+
+	// when handling the root path / the split and join will produce an empty
+	// string so to keep the absolute path set the root path directly.
+	if path.IsAbs(projectPath) && newProjectPath == "" {
+		return "/"
+	}
+
+	return newProjectPath
 }

--- a/pkg/config/shuttleconfig_test.go
+++ b/pkg/config/shuttleconfig_test.go
@@ -9,11 +9,12 @@ import (
 
 func TestShuttleConfig_getConf(t *testing.T) {
 	tt := []struct {
-		name      string
-		input     string
-		err       error
-		config    ShuttleConfig
-		foundPath string
+		name       string
+		input      string
+		strictMode bool
+		err        error
+		config     ShuttleConfig
+		foundPath  string
 	}{
 		{
 			name:  "empty path",
@@ -80,12 +81,18 @@ func TestShuttleConfig_getConf(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:       "subdir of shuttle.yaml file in strict mode",
+			input:      "testdata/valid/subdir",
+			strictMode: true,
+			err:        errors.New("exit code 2 - Failed to load shuttle configuration: shuttle.yaml file not found\n\nMake sure you are in a project using shuttle and that a 'shuttle.yaml' file is available."),
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			c := &ShuttleConfig{}
 
-			path, err := c.getConf(tc.input)
+			path, err := c.getConf(tc.input, tc.strictMode)
 
 			if tc.err != nil {
 				assert.EqualError(t, err, tc.err.Error(), "error not as expected")

--- a/pkg/config/shuttleconfig_test.go
+++ b/pkg/config/shuttleconfig_test.go
@@ -9,10 +9,11 @@ import (
 
 func TestShuttleConfig_getConf(t *testing.T) {
 	tt := []struct {
-		name   string
-		input  string
-		err    error
-		config ShuttleConfig
+		name      string
+		input     string
+		err       error
+		config    ShuttleConfig
+		foundPath string
 	}{
 		{
 			name:  "empty path",
@@ -26,12 +27,41 @@ func TestShuttleConfig_getConf(t *testing.T) {
 		{
 			name:  "unknown file",
 			input: "testdata/unknown_file",
-			err:   errors.New("exit code 2 - Failed to load shuttle configuration: open testdata/unknown_file/shuttle.yaml: no such file or directory\n\nMake sure you are in a project using shuttle and that a 'shuttle.yaml' file is available."),
+			err:   errors.New("exit code 2 - Failed to load shuttle configuration: shuttle.yaml file not found\n\nMake sure you are in a project using shuttle and that a 'shuttle.yaml' file is available."),
 		},
 		{
-			name:  "valid",
-			input: "testdata/valid",
-			err:   nil,
+			name:  "absolute path to unknown file",
+			input: "/tmp/shuttle-test/unknown",
+			err:   errors.New("exit code 2 - Failed to load shuttle configuration: shuttle.yaml file not found\n\nMake sure you are in a project using shuttle and that a 'shuttle.yaml' file is available."),
+		},
+		{
+			name:      "valid",
+			input:     "testdata/valid",
+			err:       nil,
+			foundPath: "testdata/valid",
+			config: ShuttleConfig{
+				Plan:    ".",
+				PlanRaw: ".",
+				Variables: map[string]interface{}{
+					"squad": "nasa",
+				},
+				Scripts: map[string]ShuttlePlanScript{
+					"shout": {
+						Description: "Shout hello",
+						Actions: []ShuttleAction{
+							{
+								Shell: `echo "HELLO WORLD"`,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:      "subdir of shuttle.yaml file",
+			input:     "testdata/valid/subdir",
+			err:       nil,
+			foundPath: "testdata/valid",
 			config: ShuttleConfig{
 				Plan:    ".",
 				PlanRaw: ".",
@@ -54,8 +84,8 @@ func TestShuttleConfig_getConf(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			c := &ShuttleConfig{}
-			var err error
-			c, err = c.getConf(tc.input)
+
+			path, err := c.getConf(tc.input)
 
 			if tc.err != nil {
 				assert.EqualError(t, err, tc.err.Error(), "error not as expected")
@@ -63,6 +93,7 @@ func TestShuttleConfig_getConf(t *testing.T) {
 				assert.NoError(t, err, "unexpected error")
 			}
 			assert.Equal(t, tc.config, *c, "config not as expected")
+			assert.Equal(t, tc.foundPath, path, "shuttle.yaml path not as expected")
 		})
 	}
 }

--- a/tests.sh
+++ b/tests.sh
@@ -222,5 +222,14 @@ test_run_repo_say_sha() {
   fi
 }
 
+test_run_sub_dir_say() {
+  result=$(cd examples/stepping-stone/sub-dir && ./../../../shuttle run say)
+  pwd=$(pwd)
+  normalizedOutput="${result##"$pwd"}"
+  if [[ ! "$normalizedOutput" == "/examples/stepping-stone" ]]; then
+    fail "Expected output to be '/examples/stepping-stone', but it was:\n$normalizedOutput"
+  fi
+}
+
 # Load and run shUnit2.
 . ./shunit2


### PR DESCRIPTION
Currently when shuttle is invoked it needs to be in the root of a project. This
limits its uses in scripts like go:generate where files in sub directories would
rely on the root project path.

This change adds a recursive lookup of the project path by walking backwards in
the file tree to find a shuttle.yaml file. This is a well known pattern from
other CLIs like Git where a CLI command from a sub directory acts as if it was
invoked from the project root.