### PR TITLE
Fail template rendering on template func errors

### DIFF
--- a/pkg/sdk/template_test.go
+++ b/pkg/sdk/template_test.go
@@ -1,0 +1,71 @@
+package sdk
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderTemplate(t *testing.T) {
+	tt := []struct {
+		name         string
+		templatePath string
+		output       string
+		templateCtx  TemplateContext
+		err          error
+	}{
+		{
+			name:         "valid",
+			templatePath: "testdata/valid.yaml",
+			templateCtx: TemplateContext{
+				Vars: map[string]string{
+					"bar": "bar",
+				},
+			},
+			output: `foo: bar
+`,
+			err: nil,
+		},
+		{
+			name:         "read content of unknown file",
+			templatePath: "testdata/get_file_content.yaml",
+			templateCtx: TemplateContext{
+				Vars: map[string]string{
+					"path": "unknown.yaml",
+				},
+			},
+			output: ``,
+			err:    errors.New("template: get_file_content.yaml:2:3: executing \"get_file_content.yaml\" at <getFileContent (string \"path\" .Vars)>: error calling getFileContent: open unknown.yaml: no such file or directory"),
+		},
+		{
+			name:         "read content of file",
+			templatePath: "testdata/get_file_content.yaml",
+			templateCtx: TemplateContext{
+				Vars: map[string]string{
+					"path": "testdata/valid.yaml",
+				},
+			},
+			output: `bar: baz
+foo: {{ get "bar" .Vars }}
+
+`,
+			err: nil,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			var output bytes.Buffer
+			err := renderTemplate(tc.templatePath, tc.name, &output, tc.templateCtx, "{{", "}}")
+
+			if tc.err != nil {
+				assert.EqualError(t, err, tc.err.Error())
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.output, output.String())
+		})
+	}
+}

--- a/pkg/sdk/testdata/get_file_content.yaml
+++ b/pkg/sdk/testdata/get_file_content.yaml
@@ -1,0 +1,2 @@
+bar: baz
+{{ getFileContent (string "path" .Vars) }}

--- a/pkg/sdk/testdata/get_unknown_value.yaml
+++ b/pkg/sdk/testdata/get_unknown_value.yaml
@@ -1,0 +1,1 @@
+foo: {{ get "unknown.bar" .Vars }}

--- a/pkg/sdk/testdata/valid.yaml
+++ b/pkg/sdk/testdata/valid.yaml
@@ -1,0 +1,1 @@
+foo: {{ get "bar" .Vars }}

--- a/pkg/templates/funcs.go
+++ b/pkg/templates/funcs.go
@@ -47,7 +47,6 @@ func GetFuncMap() template.FuncMap {
 	return f
 }
 
-// TODO: Add description
 func TmplGet(path string, input interface{}) interface{} {
 	if !strings.Contains(path, ".") {
 		return getInner(path, input)
@@ -70,7 +69,6 @@ func TmplStrConst(value string) string {
 	return value
 }
 
-// TODO: Add description
 func TmplString(path string, input interface{}) string {
 	value := TmplGet(path, input)
 	if value == nil {
@@ -79,7 +77,6 @@ func TmplString(path string, input interface{}) string {
 	return fmt.Sprintf("%v", value)
 }
 
-// TODO: Add description
 func TmplInt(path string, input interface{}) int {
 	value := TmplGet(path, input)
 	if value == nil {
@@ -161,44 +158,41 @@ func TmplUpperFirst(s string) string {
 	return fmt.Sprintf("%s%s", strings.ToUpper(s[0:1]), s[1:])
 }
 
-// TmplToYaml takes an interface, marshals it to yaml, and returns a string. It will
-// always return a string, even on marshal error (empty string).
+// TmplToYaml takes an interface, marshals it to yaml, and returns a string.
 //
 // This is designed to be called from a template.
 //
 // Borrowed from github.com/helm/helm/pkg/chartutil
-func TmplToYaml(v interface{}) string {
+func TmplToYaml(v interface{}) (string, error) {
 	data, err := yaml.Marshal(v)
 	if err != nil {
-		// Swallow errors inside of a template.
-		return ""
+		return "", err
 	}
-	return string(data)
+	return string(data), nil
 }
 
 // TmplFromYaml converts a YAML document into a map[string]interface{}.
 //
 // This is not a general-purpose YAML parser, and will not parse all valid
-// YAML documents. Additionally, because its intended use is within templates
-// it tolerates errors. It will insert the returned error message string into
-// m["Error"] in the returned map.
+// YAML documents.
 //
 // Borrowed from github.com/helm/helm/pkg/chartutil
-func TmplFromYaml(str string) map[string]interface{} {
+func TmplFromYaml(str string) (map[string]interface{}, error) {
 	m := map[string]interface{}{}
 
-	if err := yaml.Unmarshal([]byte(str), &m); err != nil {
-		m["Error"] = err.Error()
+	err := yaml.Unmarshal([]byte(str), &m)
+	if err != nil {
+		return nil, err
 	}
-	return m
+	return m, nil
 }
 
-func TmplGetFileContent(filePath string) string {
+func TmplGetFileContent(filePath string) (string, error) {
 	byteContent, err := ioutil.ReadFile(filePath)
 	if err != nil {
-		return "" // TODO: Print error to shuttle output
+		return "", err
 	}
-	return string(byteContent)
+	return string(byteContent), nil
 }
 
 func TmplFileExists(filePath string) bool {
@@ -211,7 +205,7 @@ func TmplFileExists(filePath string) bool {
 func TmplGetFiles(directoryPath string) []os.FileInfo {
 	files, err := ioutil.ReadDir(directoryPath)
 	if err != nil {
-		return []os.FileInfo{} // TODO: Print error to shuttle output
+		return []os.FileInfo{}
 	}
 	sort.Slice(files, func(i, j int) bool {
 		return files[i].Name() < files[j].Name()
@@ -219,7 +213,6 @@ func TmplGetFiles(directoryPath string) []os.FileInfo {
 	return files
 }
 
-// TODO: Add description
 func getInner(property string, input interface{}) interface{} {
 	switch t := input.(type) {
 	default:

--- a/pkg/templates/funcs_test.go
+++ b/pkg/templates/funcs_test.go
@@ -174,11 +174,11 @@ b:
 			input: input{
 				path: "a",
 				data: fromYaml(`a:
-  b: b 
-  d: d 
-  e: e 
-  g: g 
-  h: h 
+  b: b
+  d: d
+  e: e
+  g: g
+  h: h
   f: f
   c: c
 `),
@@ -395,4 +395,42 @@ func fromYaml(data string) interface{} {
 		log.Fatalf("faild to read yaml: %v", err)
 	}
 	return m
+}
+
+func TestTmplGetFiles(t *testing.T) {
+	tt := []struct {
+		name      string
+		directory string
+
+		files []string
+		err   error
+	}{
+		{
+			name:      "existing directory",
+			directory: "testdata/dir",
+
+			files: []string{
+				"file.test",
+			},
+			err: nil,
+		},
+		{
+			name:      "non-existing directory",
+			directory: "testdata/no-dir",
+
+			files: nil,
+			err:   nil,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			files := TmplGetFiles(tc.directory)
+
+			var foundFiles []string
+			for _, f := range files {
+				foundFiles = append(foundFiles, f.Name())
+			}
+			assert.Equal(t, tc.files, foundFiles)
+		})
+	}
 }


### PR DESCRIPTION
Currently when using template functions toYaml, fromYaml and getFileContent
fails silently or in odd ways where the rendered output contains error
information. Go's template engine supports template functions that returns
errors and thus will propagate errors correctly. This can help identify falty
paths and contents in a clear way instead of silently doing nothing.

The change is motivated by fighting with understanding why getFileContent does
nothing in some cases. As the error is hidden there are no hints as to what is
going on.

This change adds error return values to the functions along with adds some tests
of this behaviour. The functions are considered safe to change as it is unusual
to use them without expeting failures on bad input, eg. read a non-existing
file. Function getFiles is not changed to return an error as it is expected that
a non-existing or empty directory will return no files. A test is added to lock
this behaviour.