### PR TITLE
Remove type assertions in TmplObjectArray

### DIFF
--- a/pkg/templates/funcs.go
+++ b/pkg/templates/funcs.go
@@ -123,13 +123,13 @@ func TmplObjectArray(path string, input interface{}) []KeyValuePair {
 	}
 	value := TmplGet(path, input)
 	values := []KeyValuePair{}
-	switch value.(type) {
+	switch typedValue := value.(type) {
 	case map[interface{}]interface{}:
-		for k, v := range value.(map[interface{}]interface{}) {
+		for k, v := range typedValue {
 			values = append(values, KeyValuePair{Key: k.(string), Value: v})
 		}
 	case map[string]interface{}:
-		for k, v := range value.(map[string]interface{}) {
+		for k, v := range typedValue {
 			values = append(values, KeyValuePair{Key: k, Value: v})
 		}
 	}


### PR DESCRIPTION
Currently a type switch on a value in TmplObjectArray doesn't store the typed
value in the switch. This means that all cases needs to cast to the same time.
This is both error prone, eg. casting to the wrong type, and also required more
typing.

This change stored the type of the switched value which removes the error risk
and additional type casting.

This optimization was reported by go-staticcheck [rule S1034](https://staticcheck.io/docs/checks#S1034).