### PR TITLE
Changed os.stdout and os.stderr to use cobra output globally

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -86,7 +86,7 @@ Read more about shuttle at https://github.com/lunarway/shuttle`, version),
 		if verboseFlag {
 			uii = uii.SetUserLevel(ui.LevelVerbose)
 		}
-
+		uii.SetOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
 		uii.Verboseln("Running shuttle")
 		uii.Verboseln("- version: %s", version)
 		uii.Verboseln("- commit: %s", commit)

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunNoErr(t *testing.T) {
+	strings := func(s ...string) []string {
+		return s
+	}
+	tt := []struct {
+		name   string
+		input  []string
+		output string
+	}{
+		{
+			name:   "list actions",
+			input:  strings("-p", "../examples/no-plan-project", "ls"),
+			output: "Available Scripts:\n  hello        \n",
+		},
+		{
+			name:   "test moonbase build",
+			input:  strings("-p", "../examples/no-plan-project", "run", "hello"),
+			output: "Hello no plan project\n",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			rootCmd.SetOut(buf)
+			rootCmd.SetErr(buf)
+			rootCmd.SetArgs(tc.input)
+			err := rootCmd.Execute()
+
+			//cmd, err := rootCmd.ExecuteC()
+			assert.Equal(t, tc.output, buf.String())
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRunNoErr(t *testing.T) {
+func TestRoot(t *testing.T) {
 	strings := func(s ...string) []string {
 		return s
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -36,7 +36,6 @@ func TestRoot(t *testing.T) {
 			rootCmd.SetArgs(tc.input)
 			err := rootCmd.Execute()
 
-			//cmd, err := rootCmd.ExecuteC()
 			assert.Equal(t, tc.output, buf.String())
 			assert.NoError(t, err)
 		})

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/lunarway/shuttle/pkg/ui"
 	"github.com/spf13/cobra"
@@ -87,9 +86,9 @@ Installing bash completion on Linux
 		uii = uii.SetContext(ui.LevelSilent)
 		switch args[0] {
 		case "zsh":
-			runCompletionZsh(os.Stdout, rootCmd)
+			runCompletionZsh(cmd.OutOrStdout(), rootCmd)
 		case "bash":
-			rootCmd.GenBashCompletion(os.Stdout)
+			rootCmd.GenBashCompletion(cmd.OutOrStdout())
 		default:
 		}
 	},

--- a/cmd/documentation.go
+++ b/cmd/documentation.go
@@ -27,7 +27,7 @@ and respects the BROWSER environment variable.`,
 		checkError(err)
 		uii.Infoln("Documentation available at: %s", url)
 
-		browseCmd, err := browser.Command(url)
+		browseCmd, err := browser.Command(url, cmd.ErrOrStderr())
 		checkError(err)
 
 		err = browseCmd.Run()

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -36,7 +35,7 @@ var getCmd = &cobra.Command{
 		}
 		value := templates.TmplGet(path, context.Config.Variables)
 		if templ != "" {
-			err := ui.Template(os.Stdout, "get", templ, value)
+			err := ui.Template(cmd.OutOrStdout(), "get", templ, value)
 			checkError(err)
 			return
 		}

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/lunarway/shuttle/pkg/config"
 	"github.com/lunarway/shuttle/pkg/ui"
 	"github.com/spf13/cobra"
@@ -38,7 +36,7 @@ var lsCmd = &cobra.Command{
 		} else {
 			templ = lsDefaultTempl
 		}
-		err = ui.Template(os.Stdout, "ls", templ, templData{
+		err = ui.Template(cmd.OutOrStdout(), "ls", templ, templData{
 			Scripts: context.Scripts,
 			Max:     calculateRightPadForKeys(context.Scripts),
 		})

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/lunarway/shuttle/pkg/ui"
 	"github.com/spf13/cobra"
 )
@@ -53,7 +51,7 @@ Available fields are:
 		} else {
 			templ = planDefaultTempl
 		}
-		err = ui.Template(os.Stdout, "plan", templ, templData{
+		err = ui.Template(cmd.OutOrStdout(), "plan", templ, templData{
 			Plan:              context.Config.Plan,
 			PlanRaw:           context.Config.PlanRaw,
 			LocalPlanPath:     context.LocalPlanPath,

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -31,8 +31,8 @@ var (
 )
 
 func init() {
-	runCmd.SetHelpFunc(func(f *cobra.Command, args []string) {
-		scripts := f.Flags().Args()
+	runCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		scripts := cmd.Flags().Args()
 		if len(scripts) == 0 {
 			runCmd.Usage()
 			return
@@ -40,7 +40,7 @@ func init() {
 		context, err := getProjectContext()
 		checkError(err)
 
-		err = executors.Help(context.Scripts, scripts[0], os.Stdout, flagTemplate)
+		err = executors.Help(context.Scripts, scripts[0], cmd.OutOrStdout(), flagTemplate)
 		checkError(err)
 	})
 	runCmd.Flags().StringVar(&flagTemplate, "template", "", "Template string to use. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].")

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -78,7 +78,7 @@ var templateCmd = &cobra.Command{
 		}
 		var output io.Writer
 		if templateOutput == "" {
-			output = os.Stdout
+			output = cmd.OutOrStdout()
 		} else {
 			// TODO: This is probably not the right place to initialize the temp dir?
 			os.MkdirAll(projectContext.TempDirectoryPath, os.ModePerm)

--- a/pkg/browser/browser_test.go
+++ b/pkg/browser/browser_test.go
@@ -2,6 +2,7 @@ package browser
 
 import (
 	"errors"
+	"io"
 	"reflect"
 	"testing"
 )
@@ -69,7 +70,7 @@ func TestForOS(t *testing.T) {
 		}()
 
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := forOS(tt.args.goos, tt.args.url)
+			cmd := forOS(tt.args.goos, tt.args.url, io.Discard)
 			if !reflect.DeepEqual(cmd.Args, tt.want) {
 				t.Errorf("ForOS() = %v, want %v", cmd.Args, tt.want)
 			}

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"io"
 	"os"
 )
 
@@ -11,6 +12,8 @@ type UI struct {
 	DefaultLevel   Level
 	UserLevel      Level
 	UserLevelSet   bool
+	Out            io.Writer
+	Err            io.Writer
 }
 
 // Create doc
@@ -19,7 +22,14 @@ func Create() UI {
 		EffectiveLevel: LevelInfo,
 		DefaultLevel:   LevelInfo,
 		UserLevelSet:   false,
+		Out:            os.Stdout,
+		Err:            os.Stderr,
 	}
+}
+
+func (ui *UI) SetOutput(out io.Writer, err io.Writer) {
+	ui.Out = out
+	ui.Err = err
 }
 
 // SetUserLevel doc
@@ -29,6 +39,8 @@ func (ui *UI) SetUserLevel(level Level) UI {
 		DefaultLevel:   ui.DefaultLevel,
 		UserLevel:      level,
 		UserLevelSet:   true,
+		Out:            ui.Out,
+		Err:            ui.Err,
 	}
 }
 
@@ -46,26 +58,28 @@ func (ui *UI) SetContext(level Level) UI {
 		DefaultLevel:   level,
 		UserLevel:      ui.UserLevel,
 		UserLevelSet:   ui.UserLevelSet,
+		Out:            ui.Out,
+		Err:            ui.Err,
 	}
 }
 
 // Verboseln prints a formatted verbose message line.
 func (ui *UI) Verboseln(format string, args ...interface{}) {
 	if ui.EffectiveLevel.OutputIsIncluded(LevelVerbose) {
-		fmt.Println(fmt.Sprintf(format, args...))
+		fmt.Fprintln(ui.Out, fmt.Sprintf(format, args...))
 	}
 }
 
 // Infoln prints a formatted info message line.
 func (ui *UI) Infoln(format string, args ...interface{}) {
 	if ui.EffectiveLevel.OutputIsIncluded(LevelInfo) {
-		fmt.Println(fmt.Sprintf(format, args...))
+		fmt.Fprintln(ui.Out, fmt.Sprintf(format, args...))
 	}
 }
 
 func (ui *UI) EmphasizeInfoln(format string, args ...interface{}) {
 	if ui.EffectiveLevel.OutputIsIncluded(LevelInfo) {
-		fmt.Printf("\x1b[032;1m%s\x1b[0m\n", fmt.Sprintf(format, args...))
+		fmt.Fprintf(ui.Out, "\x1b[032;1m%s\x1b[0m\n", fmt.Sprintf(format, args...))
 	}
 }
 
@@ -77,6 +91,6 @@ func (ui *UI) Titleln(format string, args ...interface{}) {
 // Errorln doc
 func (ui *UI) Errorln(format string, args ...interface{}) {
 	if ui.EffectiveLevel.OutputIsIncluded(LevelError) {
-		fmt.Fprintf(os.Stderr, "\x1b[31;1m%s\x1b[0m\n", fmt.Sprintf(format, args...))
+		fmt.Fprintf(ui.Err, "\x1b[31;1m%s\x1b[0m\n", fmt.Sprintf(format, args...))
 	}
 }


### PR DESCRIPTION
Creating Go tests was hard with Shuttle as most of the code simply used `os.stdout` and `os.stderr` when writing output. That way it is hard to capture this in go tests. So we needed to align all writers to use the same as set for `Cobra`. This PR also adds two initial tests to get started. 