### PR TITLE
rename cmd_test and adding ls_test

### DIFF
--- a/cmd/ls_test.go
+++ b/cmd/ls_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLsNoErr(t *testing.T) {
+func TestLs(t *testing.T) {
 	strings := func(s ...string) []string {
 		return s
 	}

--- a/cmd/ls_test.go
+++ b/cmd/ls_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRoot(t *testing.T) {
+func TestLsNoErr(t *testing.T) {
 	strings := func(s ...string) []string {
 		return s
 	}
@@ -17,14 +17,14 @@ func TestRoot(t *testing.T) {
 		output string
 	}{
 		{
-			name:   "list actions",
+			name:   "list one action",
 			input:  strings("-p", "../examples/no-plan-project", "ls"),
 			output: "Available Scripts:\n  hello        \n",
 		},
 		{
-			name:   "test moonbase build",
-			input:  strings("-p", "../examples/no-plan-project", "run", "hello"),
-			output: "Hello no plan project\n",
+			name:   "list actions",
+			input:  strings("-p", "../examples/repo-project/", "ls"),
+			output: "Pulling latest plan changes on master\nAvailable Scripts:\n  build        Build the docker image\n  deploy       Deploys the image to a kubernetes environment\n  push         Push the docker image\n  say          Say something\n  test         Run test for the project\n",
 		},
 	}
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRoot(t *testing.T) {
+	strings := func(s ...string) []string {
+		return s
+	}
+	tt := []struct {
+		name   string
+		input  []string
+		output string
+	}{
+		{
+			name:   "test moonbase build",
+			input:  strings("-p", "../examples/no-plan-project", "run", "hello"),
+			output: "Hello no plan project\n",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			rootCmd.SetOut(buf)
+			rootCmd.SetErr(buf)
+			rootCmd.SetArgs(tc.input)
+			err := rootCmd.Execute()
+
+			assert.Equal(t, tc.output, buf.String())
+			assert.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Currently the cmd_test is testing the run and ls endpoints. This needs to be split up moving forward, and this PR prepares that splitup. 