### PR TITLE
Fix get using cmd print

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -46,7 +47,7 @@ var getCmd = &cobra.Command{
 			if err != nil {
 				checkError(errors.NewExitCode(9, "Could not yaml encode value '%s'\nError: %s", value, err))
 			}
-			cmd.Print(strings.TrimRight(string(x), "\n"))
+			fmt.Fprint(cmd.OutOrStdout(), strings.TrimRight(string(x), "\n"))
 		}
 	},
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -47,7 +46,7 @@ var getCmd = &cobra.Command{
 			if err != nil {
 				checkError(errors.NewExitCode(9, "Could not yaml encode value '%s'\nError: %s", value, err))
 			}
-			fmt.Print(strings.TrimRight(string(x), "\n"))
+			cmd.Print(strings.TrimRight(string(x), "\n"))
 		}
 	},
 }

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetNoErr(t *testing.T) {
+func TestGet(t *testing.T) {
 	strings := func(s ...string) []string {
 		return s
 	}

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetNoErr(t *testing.T) {
+	strings := func(s ...string) []string {
+		return s
+	}
+	tt := []struct {
+		name   string
+		input  []string
+		output string
+	}{
+		{
+			name:   "get variable",
+			input:  strings("-p", "../examples/repo-project", "get", "docker.baseImage"),
+			output: "golang",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			rootCmd.SetOut(buf)
+			rootCmd.SetErr(buf)
+			rootCmd.SetArgs(tc.input)
+			err := rootCmd.Execute()
+
+			assert.NoError(t, err)
+
+			if tc.output != "" {
+				assert.Equal(t, tc.output, buf.String())
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
get.go uses fmt.print which doesnt respect the output setting set by cmd (in Cobra). This changes this, and adds a test that tests this. The change enables us to capture the output in go tests. 