### PR TITLE
Added test for has cmd and fixed exit return

### DIFF
--- a/cmd/has.go
+++ b/cmd/has.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
+	"github.com/lunarway/shuttle/pkg/errors"
 	"github.com/lunarway/shuttle/pkg/templates"
 	"github.com/lunarway/shuttle/pkg/ui"
 	"github.com/spf13/cobra"
@@ -13,11 +13,13 @@ var (
 	lookupInScripts bool
 	outputAsStdout  bool
 	hasCmd          = &cobra.Command{
-		Use:   "has [variable]",
-		Short: "Check if a variable (or script) is defined",
-		Args:  cobra.ExactArgs(1),
+		Use:           "has [variable]",
+		Short:         "Check if a variable (or script) is defined",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
 		//Long:  ``,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			uii = uii.SetContext(ui.LevelSilent)
 
 			context, err := getProjectContext()
@@ -39,11 +41,12 @@ var (
 				} else {
 					fmt.Print("false")
 				}
+				return nil
 			} else {
 				if found {
-					os.Exit(0)
+					return nil
 				} else {
-					os.Exit(1)
+					return errors.NewExitCode(1, "")
 				}
 			}
 		},

--- a/cmd/has_test.go
+++ b/cmd/has_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasNoErr(t *testing.T) {
+	strings := func(s ...string) []string {
+		return s
+	}
+	tt := []struct {
+		name   string
+		input  []string
+		output string
+	}{
+		{
+			name:   "has variable",
+			input:  strings("-p", "../examples/repo-project", "has", "docker.baseImage"),
+			output: "",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			rootCmd.SetOut(buf)
+			rootCmd.SetErr(buf)
+			rootCmd.SetArgs(tc.input)
+			err := rootCmd.Execute()
+
+			assert.NoError(t, err)
+
+			if tc.output != "" {
+				assert.Equal(t, tc.output, buf.String())
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
Having tests done by `bash` is a problem and we want to migrate to go tests instead. This PR add the first go test and fixes a problem with the has `exit 0` response that is hard to test in go