### PR TITLE
Refactor test logic

### DIFF
--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -1,42 +1,21 @@
 package cmd
 
 import (
-	"bytes"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGet(t *testing.T) {
 	strings := func(s ...string) []string {
 		return s
 	}
-	tt := []struct {
-		name   string
-		input  []string
-		output string
-	}{
+	testCases := []testCase{
 		{
-			name:   "get variable",
-			input:  strings("-p", "../examples/repo-project", "get", "docker.baseImage"),
-			output: "golang",
+			name:      "get variable",
+			input:     strings("-p", "../examples/repo-project", "get", "docker.baseImage"),
+			stdoutput: "golang",
+			erroutput: "",
+			err:       nil,
 		},
 	}
-
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
-			buf := new(bytes.Buffer)
-			rootCmd.SetOut(buf)
-			rootCmd.SetErr(buf)
-			rootCmd.SetArgs(tc.input)
-			err := rootCmd.Execute()
-
-			assert.NoError(t, err)
-
-			if tc.output != "" {
-				assert.Equal(t, tc.output, buf.String())
-			}
-
-		})
-	}
+	executeTestCases(t, testCases)
 }

--- a/cmd/has_test.go
+++ b/cmd/has_test.go
@@ -1,20 +1,9 @@
 package cmd
 
 import (
-	"bytes"
 	"fmt"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
-
-type testCase struct {
-	name      string
-	input     []string
-	stdoutput string
-	erroutput string
-	err       error
-}
 
 func TestHas(t *testing.T) {
 	strings := func(s ...string) []string {
@@ -38,26 +27,4 @@ func TestHas(t *testing.T) {
 		},
 	}
 	executeTestCases(t, testCases)
-}
-
-func executeTestCases(t *testing.T, testCases []testCase) {
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			stdBuf := new(bytes.Buffer)
-			errBuf := new(bytes.Buffer)
-
-			rootCmd.SetOut(stdBuf)
-			rootCmd.SetErr(errBuf)
-			rootCmd.SetArgs(tc.input)
-
-			err := rootCmd.Execute()
-			if tc.err == nil {
-				assert.NoError(t, err)
-			} else {
-				assert.EqualError(t, tc.err, err.Error())
-			}
-			assert.Equal(t, tc.stdoutput, stdBuf.String())
-			assert.Equal(t, tc.erroutput, errBuf.String())
-		})
-	}
 }

--- a/cmd/has_test.go
+++ b/cmd/has_test.go
@@ -2,41 +2,62 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestHasNoErr(t *testing.T) {
+type testCase struct {
+	name      string
+	input     []string
+	stdoutput string
+	erroutput string
+	err       error
+}
+
+func TestHas(t *testing.T) {
 	strings := func(s ...string) []string {
 		return s
 	}
-	tt := []struct {
-		name   string
-		input  []string
-		output string
-	}{
+
+	testCases := []testCase{
 		{
-			name:   "has variable",
-			input:  strings("-p", "../examples/repo-project", "has", "docker.baseImage"),
-			output: "",
+			name:      "has variable",
+			input:     strings("-p", "../examples/repo-project", "has", "docker.baseImage"),
+			stdoutput: "",
+			erroutput: "",
+			err:       nil,
+		},
+		{
+			name:      "has wrong argument switch",
+			input:     strings("-j", "../examples/repo-project", "has", "docker.baseImage"),
+			stdoutput: "",
+			erroutput: "",
+			err:       fmt.Errorf("unknown shorthand flag: 'j' in -j"),
 		},
 	}
+	executeTestCases(t, testCases)
+}
 
-	for _, tc := range tt {
+func executeTestCases(t *testing.T, testCases []testCase) {
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			buf := new(bytes.Buffer)
-			rootCmd.SetOut(buf)
-			rootCmd.SetErr(buf)
+			stdBuf := new(bytes.Buffer)
+			errBuf := new(bytes.Buffer)
+
+			rootCmd.SetOut(stdBuf)
+			rootCmd.SetErr(errBuf)
 			rootCmd.SetArgs(tc.input)
+
 			err := rootCmd.Execute()
-
-			assert.NoError(t, err)
-
-			if tc.output != "" {
-				assert.Equal(t, tc.output, buf.String())
+			if tc.err == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, tc.err, err.Error())
 			}
-
+			assert.Equal(t, tc.stdoutput, stdBuf.String())
+			assert.Equal(t, tc.erroutput, errBuf.String())
 		})
 	}
 }

--- a/cmd/ls_test.go
+++ b/cmd/ls_test.go
@@ -1,43 +1,28 @@
 package cmd
 
 import (
-	"bytes"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestLs(t *testing.T) {
 	strings := func(s ...string) []string {
 		return s
 	}
-	tt := []struct {
-		name   string
-		input  []string
-		output string
-	}{
+	testCases := []testCase{
 		{
-			name:   "list one action",
-			input:  strings("-p", "../examples/no-plan-project", "ls"),
-			output: "Available Scripts:\n  hello        \n",
+			name:      "list one action",
+			input:     strings("-p", "../examples/no-plan-project", "ls"),
+			stdoutput: "Available Scripts:\n  hello        \n",
+			erroutput: "",
+			err:       nil,
 		},
 		{
-			name:   "list actions",
-			input:  strings("-p", "../examples/repo-project/", "ls"),
-			output: "Pulling latest plan changes on master\nAvailable Scripts:\n  build        Build the docker image\n  deploy       Deploys the image to a kubernetes environment\n  push         Push the docker image\n  say          Say something\n  test         Run test for the project\n",
+			name:      "list actions",
+			input:     strings("-p", "../examples/repo-project/", "ls"),
+			stdoutput: "Pulling latest plan changes on master\nAvailable Scripts:\n  build        Build the docker image\n  deploy       Deploys the image to a kubernetes environment\n  push         Push the docker image\n  say          Say something\n  test         Run test for the project\n",
+			erroutput: "",
+			err:       nil,
 		},
 	}
-
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
-			buf := new(bytes.Buffer)
-			rootCmd.SetOut(buf)
-			rootCmd.SetErr(buf)
-			rootCmd.SetArgs(tc.input)
-			err := rootCmd.Execute()
-
-			assert.Equal(t, tc.output, buf.String())
-			assert.NoError(t, err)
-		})
-	}
+	executeTestCases(t, testCases)
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,38 +1,21 @@
 package cmd
 
 import (
-	"bytes"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestRoot(t *testing.T) {
 	strings := func(s ...string) []string {
 		return s
 	}
-	tt := []struct {
-		name   string
-		input  []string
-		output string
-	}{
+	testCases := []testCase{
 		{
-			name:   "test moonbase build",
-			input:  strings("-p", "../examples/no-plan-project", "run", "hello"),
-			output: "Hello no plan project\n",
+			name:      "test moonbase build",
+			input:     strings("-p", "../examples/no-plan-project", "run", "hello"),
+			stdoutput: "Hello no plan project\n",
+			erroutput: "",
+			err:       nil,
 		},
 	}
-
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
-			buf := new(bytes.Buffer)
-			rootCmd.SetOut(buf)
-			rootCmd.SetErr(buf)
-			rootCmd.SetArgs(tc.input)
-			err := rootCmd.Execute()
-
-			assert.Equal(t, tc.output, buf.String())
-			assert.NoError(t, err)
-		})
-	}
+	executeTestCases(t, testCases)
 }

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testCase struct {
+	name      string
+	input     []string
+	stdoutput string
+	erroutput string
+	err       error
+}
+
+func executeTestCases(t *testing.T, testCases []testCase) {
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			stdBuf := new(bytes.Buffer)
+			errBuf := new(bytes.Buffer)
+
+			rootCmd.SetOut(stdBuf)
+			rootCmd.SetErr(errBuf)
+			rootCmd.SetArgs(tc.input)
+
+			err := rootCmd.Execute()
+			if tc.err == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, tc.err, err.Error())
+			}
+			assert.Equal(t, tc.stdoutput, stdBuf.String())
+			assert.Equal(t, tc.erroutput, errBuf.String())
+		})
+	}
+}


### PR DESCRIPTION
The current go test logic is placed in each test file. This PR moves this into its own file `test.go` that is then used by each test. This simplifies each testfile greatly. Each of the tests that are already made has been refactored to use this shared test logic. 