### PR TITLE
Remove global cobra command state

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -66,7 +66,6 @@ __shuttle_custom_func() {
 }
 `
 
-// rootCmd represents the base command when called without any subcommands
 func newRoot(uii *ui.UI) (*cobra.Command, contextProvider) {
 	var (
 		verboseFlag        bool
@@ -129,17 +128,17 @@ func initializedRoot() *cobra.Command {
 
 	rootCmd, ctxProvider := newRoot(&uii)
 
-	rootCmd.AddCommand(newDocumentationCommand(&uii, ctxProvider))
-	rootCmd.AddCommand(newCompletionCmd(&uii))
-	rootCmd.AddCommand(newGetCmd(&uii, ctxProvider))
-	rootCmd.AddCommand(newGitPlanCmd(&uii, ctxProvider))
-	rootCmd.AddCommand(newHasCmd(&uii, ctxProvider))
-	rootCmd.AddCommand(newLsCmd(&uii, ctxProvider))
-	rootCmd.AddCommand(newPlanCmd(&uii, ctxProvider))
-	rootCmd.AddCommand(newPrepareCmd(&uii, ctxProvider))
-	rootCmd.AddCommand(newRunCmd(&uii, ctxProvider))
-	rootCmd.AddCommand(newTemplateCmd(&uii, ctxProvider))
-	rootCmd.AddCommand(newVersionCmd(&uii))
+	rootCmd.AddCommand(newDocumentation(&uii, ctxProvider))
+	rootCmd.AddCommand(newCompletion(&uii))
+	rootCmd.AddCommand(newGet(&uii, ctxProvider))
+	rootCmd.AddCommand(newGitPlan(&uii, ctxProvider))
+	rootCmd.AddCommand(newHas(&uii, ctxProvider))
+	rootCmd.AddCommand(newLs(&uii, ctxProvider))
+	rootCmd.AddCommand(newPlan(&uii, ctxProvider))
+	rootCmd.AddCommand(newPrepare(&uii, ctxProvider))
+	rootCmd.AddCommand(newRun(&uii, ctxProvider))
+	rootCmd.AddCommand(newTemplate(&uii, ctxProvider))
+	rootCmd.AddCommand(newVersion(&uii))
 
 	return rootCmd
 }

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -23,8 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// completionCmd represents the completion command
-func newCompletionCmd(uii *ui.UI) *cobra.Command {
+func newCompletion(uii *ui.UI) *cobra.Command {
 	completionCmd := &cobra.Command{
 		Use:   "completion <shell>",
 		Short: `Output shell completion code`,

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -24,10 +24,11 @@ import (
 )
 
 // completionCmd represents the completion command
-var completionCmd = &cobra.Command{
-	Use:   "completion <shell>",
-	Short: `Output shell completion code`,
-	Long: `Output shell completion code for the specified shell (bash or zsh).
+func newCompletionCmd(uii *ui.UI) *cobra.Command {
+	completionCmd := &cobra.Command{
+		Use:   "completion <shell>",
+		Short: `Output shell completion code`,
+		Long: `Output shell completion code for the specified shell (bash or zsh).
 The shell code must be evaluated to provide interactive
 completion of shuttle commands.  This can be done by sourcing it from
 the .bash_profile.
@@ -73,27 +74,26 @@ Installing bash completion on Linux
     Set the shuttle completion code for zsh[1] to autoload on startup
 
     	shuttle completion zsh > "${fpath[1]}/_shuttle"`,
-	ValidArgs: []string{"bash", "zsh"},
-	Args: func(cmd *cobra.Command, args []string) error {
-		if cobra.ExactArgs(1)(cmd, args) != nil || cobra.OnlyValidArgs(cmd, args) != nil {
-			return fmt.Errorf("only %v arguments are allowed", cmd.ValidArgs)
-		}
-		return nil
-	},
-	Run: func(cmd *cobra.Command, args []string) {
-		uii = uii.SetContext(ui.LevelSilent)
-		switch args[0] {
-		case "zsh":
-			runCompletionZsh(cmd.OutOrStdout(), rootCmd)
-		case "bash":
-			rootCmd.GenBashCompletion(cmd.OutOrStdout())
-		default:
-		}
-	},
-}
+		ValidArgs: []string{"bash", "zsh"},
+		Args: func(cmd *cobra.Command, args []string) error {
+			if cobra.ExactArgs(1)(cmd, args) != nil || cobra.OnlyValidArgs(cmd, args) != nil {
+				return fmt.Errorf("only %v arguments are allowed", cmd.ValidArgs)
+			}
+			return nil
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			*uii = uii.SetContext(ui.LevelSilent)
+			switch args[0] {
+			case "zsh":
+				runCompletionZsh(cmd.OutOrStdout(), cmd.Root())
+			case "bash":
+				cmd.Root().GenBashCompletion(cmd.OutOrStdout())
+			default:
+			}
+		},
+	}
 
-func init() {
-	rootCmd.AddCommand(completionCmd)
+	return completionCmd
 }
 
 // this writes a zsh completion script that wraps the bash completion script.

--- a/cmd/documentation.go
+++ b/cmd/documentation.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newDocumentationCommand(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
+func newDocumentation(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 	documentationCommand := &cobra.Command{
 		Use:     "documentation",
 		Aliases: []string{"docs"},

--- a/cmd/documentation.go
+++ b/cmd/documentation.go
@@ -3,14 +3,16 @@ package cmd
 import (
 	"github.com/lunarway/shuttle/pkg/browser"
 	"github.com/lunarway/shuttle/pkg/errors"
+	"github.com/lunarway/shuttle/pkg/ui"
 	"github.com/spf13/cobra"
 )
 
-var documentationCommand = &cobra.Command{
-	Use:     "documentation",
-	Aliases: []string{"docs"},
-	Short:   "Open documentation for the configured shuttle plan",
-	Long: `Open documentation for the configured shuttle plan.
+func newDocumentationCommand(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
+	documentationCommand := &cobra.Command{
+		Use:     "documentation",
+		Aliases: []string{"docs"},
+		Short:   "Open documentation for the configured shuttle plan",
+		Long: `Open documentation for the configured shuttle plan.
 By default shuttle will try to open the plan's documentation in a web browser.
 
 If no docs are explicitly configured in the plan, the plan it self is opened.
@@ -18,25 +20,24 @@ Usually this will target a hosted git repository, eg. GitHub README.
 
 The application to open the documentation is inferred from the operating system
 and respects the BROWSER environment variable.`,
-	Args: cobra.ExactArgs(0),
-	Run: func(cmd *cobra.Command, args []string) {
-		context, err := getProjectContext()
-		checkError(err)
+		Args: cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			context, err := contextProvider()
+			checkError(uii, err)
 
-		url, err := context.DocumentationURL()
-		checkError(err)
-		uii.Infoln("Documentation available at: %s", url)
+			url, err := context.DocumentationURL()
+			checkError(uii, err)
+			uii.Infoln("Documentation available at: %s", url)
 
-		browseCmd, err := browser.Command(url, cmd.ErrOrStderr())
-		checkError(err)
+			browseCmd, err := browser.Command(url, cmd.ErrOrStderr())
+			checkError(uii, err)
 
-		err = browseCmd.Run()
-		if err != nil {
-			checkError(errors.NewExitCode(1, "Failed to open document reference: %v", err))
-		}
-	},
-}
+			err = browseCmd.Run()
+			if err != nil {
+				checkError(uii, errors.NewExitCode(1, "Failed to open document reference: %v", err))
+			}
+		},
+	}
 
-func init() {
-	rootCmd.AddCommand(documentationCommand)
+	return documentationCommand
 }

--- a/cmd/error.go
+++ b/cmd/error.go
@@ -6,9 +6,10 @@ import (
 	"os"
 
 	shuttleerrors "github.com/lunarway/shuttle/pkg/errors"
+	"github.com/lunarway/shuttle/pkg/ui"
 )
 
-func checkError(err error) {
+func checkError(uii *ui.UI, err error) {
 	if err == nil {
 		return
 	}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newGetCmd(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
+func newGet(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 	var getFlagTemplate string
 	getCmd := &cobra.Command{
 		Use:   "get [variable]",

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -13,46 +13,42 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	getFlagTemplate string
-)
-
-type dynamicValue = interface{}
-
-var getCmd = &cobra.Command{
-	Use:   "get [variable]",
-	Short: "Get a variable value",
-	Args:  cobra.ExactArgs(1),
-	//Long:  ``,
-	Run: func(cmd *cobra.Command, args []string) {
-		uii = uii.SetContext(ui.LevelError)
-		context, err := getProjectContext()
-		checkError(err)
-		path := args[0]
-		var templ string
-		if getFlagTemplate != "" {
-			templ = getFlagTemplate
-		}
-		value := templates.TmplGet(path, context.Config.Variables)
-		if templ != "" {
-			err := ui.Template(cmd.OutOrStdout(), "get", templ, value)
-			checkError(err)
-			return
-		}
-		switch value.(type) {
-		case nil:
-			// print nothing
-		default:
-			x, err := yaml.Marshal(value)
-			if err != nil {
-				checkError(errors.NewExitCode(9, "Could not yaml encode value '%s'\nError: %s", value, err))
+func newGetCmd(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
+	var getFlagTemplate string
+	getCmd := &cobra.Command{
+		Use:   "get [variable]",
+		Short: "Get a variable value",
+		Args:  cobra.ExactArgs(1),
+		//Long:  ``,
+		Run: func(cmd *cobra.Command, args []string) {
+			*uii = uii.SetContext(ui.LevelError)
+			context, err := contextProvider()
+			checkError(uii, err)
+			path := args[0]
+			var templ string
+			if getFlagTemplate != "" {
+				templ = getFlagTemplate
 			}
-			fmt.Fprint(cmd.OutOrStdout(), strings.TrimRight(string(x), "\n"))
-		}
-	},
-}
+			value := templates.TmplGet(path, context.Config.Variables)
+			if templ != "" {
+				err := ui.Template(cmd.OutOrStdout(), "get", templ, value)
+				checkError(uii, err)
+				return
+			}
+			switch value.(type) {
+			case nil:
+				// print nothing
+			default:
+				x, err := yaml.Marshal(value)
+				if err != nil {
+					checkError(uii, errors.NewExitCode(9, "Could not yaml encode value '%s'\nError: %s", value, err))
+				}
+				fmt.Fprint(cmd.OutOrStdout(), strings.TrimRight(string(x), "\n"))
+			}
+		},
+	}
 
-func init() {
 	getCmd.Flags().StringVar(&getFlagTemplate, "template", "", "Template string to use. See --help for details.")
-	rootCmd.AddCommand(getCmd)
+
+	return getCmd
 }

--- a/cmd/git-plan.go
+++ b/cmd/git-plan.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newGitPlanCmd(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
+func newGitPlan(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 	gitPlanCmd := &cobra.Command{
 		Use:   "git-plan [...git_args]",
 		Short: "Run a git command for the plan",

--- a/cmd/git-plan.go
+++ b/cmd/git-plan.go
@@ -4,22 +4,22 @@ import (
 	"strings"
 
 	"github.com/lunarway/shuttle/pkg/git"
+	"github.com/lunarway/shuttle/pkg/ui"
 	"github.com/spf13/cobra"
 )
 
-var (
-	gitPlanCmd = &cobra.Command{
+func newGitPlanCmd(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
+	gitPlanCmd := &cobra.Command{
 		Use:   "git-plan [...git_args]",
 		Short: "Run a git command for the plan",
 		Run: func(cmd *cobra.Command, args []string) {
-			skipGitPlanPulling = true
-			context, err := getProjectContext()
-			checkError(err)
+			// TODO: this is no longer possible to configure
+			// skipGitPlanPulling = true
+			context, err := contextProvider()
+			checkError(uii, err)
 			git.RunGitPlanCommand(strings.Join(args, " "), context.LocalPlanPath, context.UI)
 		},
 	}
-)
 
-func init() {
-	rootCmd.AddCommand(gitPlanCmd)
+	return gitPlanCmd
 }

--- a/cmd/has.go
+++ b/cmd/has.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newHasCmd(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
+func newHas(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 	var (
 		lookupInScripts bool
 		outputAsStdout  bool

--- a/cmd/has.go
+++ b/cmd/has.go
@@ -9,10 +9,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	lookupInScripts bool
-	outputAsStdout  bool
-	hasCmd          = &cobra.Command{
+func newHasCmd(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
+	var (
+		lookupInScripts bool
+		outputAsStdout  bool
+	)
+
+	hasCmd := &cobra.Command{
 		Use:           "has [variable]",
 		Short:         "Check if a variable (or script) is defined",
 		Args:          cobra.ExactArgs(1),
@@ -20,10 +23,10 @@ var (
 		SilenceErrors: true,
 		//Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			uii = uii.SetContext(ui.LevelSilent)
+			*uii = uii.SetContext(ui.LevelSilent)
 
-			context, err := getProjectContext()
-			checkError(err)
+			context, err := contextProvider()
+			checkError(uii, err)
 
 			variable := args[0]
 
@@ -51,10 +54,9 @@ var (
 			}
 		},
 	}
-)
 
-func init() {
 	hasCmd.Flags().BoolVar(&lookupInScripts, "script", false, "Lookup existence in scripts instead of vars")
 	hasCmd.Flags().BoolVarP(&outputAsStdout, "stdout", "o", false, "Print result to stdout instead of exit code as `true` or `false`")
-	rootCmd.AddCommand(hasCmd)
+
+	return hasCmd
 }

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -14,39 +14,38 @@ Available Scripts:
 {{- end}}
 `
 
-var (
-	lsFlagTemplate string
-)
-
 type templData struct {
 	Scripts map[string]config.ShuttlePlanScript
 	Max     int
 }
 
-var lsCmd = &cobra.Command{
-	Use:   "ls [command]",
-	Short: "List possible commands",
-	Run: func(cmd *cobra.Command, args []string) {
-		context, err := getProjectContext()
-		checkError(err)
+func newLsCmd(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
+	var lsFlagTemplate string
 
-		var templ string
-		if lsFlagTemplate != "" {
-			templ = lsFlagTemplate
-		} else {
-			templ = lsDefaultTempl
-		}
-		err = ui.Template(cmd.OutOrStdout(), "ls", templ, templData{
-			Scripts: context.Scripts,
-			Max:     calculateRightPadForKeys(context.Scripts),
-		})
-		checkError(err)
-	},
-}
+	lsCmd := &cobra.Command{
+		Use:   "ls [command]",
+		Short: "List possible commands",
+		Run: func(cmd *cobra.Command, args []string) {
+			context, err := contextProvider()
+			checkError(uii, err)
 
-func init() {
+			var templ string
+			if lsFlagTemplate != "" {
+				templ = lsFlagTemplate
+			} else {
+				templ = lsDefaultTempl
+			}
+			err = ui.Template(cmd.OutOrStdout(), "ls", templ, templData{
+				Scripts: context.Scripts,
+				Max:     calculateRightPadForKeys(context.Scripts),
+			})
+			checkError(uii, err)
+		},
+	}
+
 	lsCmd.Flags().StringVar(&lsFlagTemplate, "template", "", "Template string to use. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].")
-	rootCmd.AddCommand(lsCmd)
+
+	return lsCmd
 }
 
 func calculateRightPadForKeys(m map[string]config.ShuttlePlanScript) int {

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -19,7 +19,7 @@ type templData struct {
 	Max     int
 }
 
-func newLsCmd(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
+func newLs(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 	var lsFlagTemplate string
 
 	lsCmd := &cobra.Command{

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -11,7 +11,7 @@ var (
 	planFlagTemplate string
 )
 
-func newPlanCmd(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
+func newPlan(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 	planCmd := &cobra.Command{
 		Use:   "plan",
 		Short: "Output plan information to stdout",

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -11,10 +11,11 @@ var (
 	planFlagTemplate string
 )
 
-var planCmd = &cobra.Command{
-	Use:   "plan",
-	Short: "Output plan information to stdout",
-	Long: `Output plan information to stdout.
+func newPlanCmd(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
+	planCmd := &cobra.Command{
+		Use:   "plan",
+		Short: "Output plan information to stdout",
+		Long: `Output plan information to stdout.
 By default the plan name is output. For projects without a plan (plan: false) an
 empty string is written.
 
@@ -30,39 +31,39 @@ Available fields are:
   .TempDirectoryPath Path to the temporary files of the plan on the local file
                      system.
 `,
-	Example: `Get the raw plan string as it is written in the shuttle.yaml file:
+		Example: `Get the raw plan string as it is written in the shuttle.yaml file:
   shuttle plan --template '{{.PlanRaw}}'`,
-	Args: cobra.ExactArgs(0),
-	Run: func(cmd *cobra.Command, args []string) {
-		type templData struct {
-			LocalPlanPath     string
-			Plan              string
-			PlanRaw           interface{}
-			ProjectPath       string
-			TempDirectoryPath string
-		}
-		uii = uii.SetUserLevel(ui.LevelError)
-		context, err := getProjectContext()
-		checkError(err)
+		Args: cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			type templData struct {
+				LocalPlanPath     string
+				Plan              string
+				PlanRaw           interface{}
+				ProjectPath       string
+				TempDirectoryPath string
+			}
+			*uii = uii.SetUserLevel(ui.LevelError)
+			context, err := contextProvider()
+			checkError(uii, err)
 
-		var templ string
-		if planFlagTemplate != "" {
-			templ = planFlagTemplate
-		} else {
-			templ = planDefaultTempl
-		}
-		err = ui.Template(cmd.OutOrStdout(), "plan", templ, templData{
-			Plan:              context.Config.Plan,
-			PlanRaw:           context.Config.PlanRaw,
-			LocalPlanPath:     context.LocalPlanPath,
-			ProjectPath:       context.ProjectPath,
-			TempDirectoryPath: context.TempDirectoryPath,
-		})
-		checkError(err)
-	},
-}
+			var templ string
+			if planFlagTemplate != "" {
+				templ = planFlagTemplate
+			} else {
+				templ = planDefaultTempl
+			}
+			err = ui.Template(cmd.OutOrStdout(), "plan", templ, templData{
+				Plan:              context.Config.Plan,
+				PlanRaw:           context.Config.PlanRaw,
+				LocalPlanPath:     context.LocalPlanPath,
+				ProjectPath:       context.ProjectPath,
+				TempDirectoryPath: context.TempDirectoryPath,
+			})
+			checkError(uii, err)
+		},
+	}
 
-func init() {
 	planCmd.Flags().StringVar(&planFlagTemplate, "template", "", "Template string to use. See --help for details.")
-	rootCmd.AddCommand(planCmd)
+
+	return planCmd
 }

--- a/cmd/prepare.go
+++ b/cmd/prepare.go
@@ -5,7 +5,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newPrepareCmd(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
+func newPrepare(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 	prepareCmd := &cobra.Command{
 		Use:   "prepare",
 		Short: "Load external resources",

--- a/cmd/prepare.go
+++ b/cmd/prepare.go
@@ -1,21 +1,20 @@
 package cmd
 
 import (
+	"github.com/lunarway/shuttle/pkg/ui"
 	"github.com/spf13/cobra"
 )
 
-var (
-	prepareCmd = &cobra.Command{
+func newPrepareCmd(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
+	prepareCmd := &cobra.Command{
 		Use:   "prepare",
 		Short: "Load external resources",
 		Long:  `Load external resources as a preparation step, before starting to use shuttle`,
 		Run: func(cmd *cobra.Command, args []string) {
-			_, err := getProjectContext()
-			checkError(err)
+			_, err := contextProvider()
+			checkError(uii, err)
 		},
 	}
-)
 
-func init() {
-	rootCmd.AddCommand(prepareCmd)
+	return prepareCmd
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newRunCmd(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
+func newRun(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 	var (
 		flagTemplate string
 		validateArgs bool

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -9,6 +9,7 @@ import (
 	"text/template"
 
 	tmplFuncs "github.com/lunarway/shuttle/pkg/templates"
+	"github.com/lunarway/shuttle/pkg/ui"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -20,92 +21,94 @@ type context struct {
 	ProjectPath string
 }
 
-var templateOutput, leftDelimArg, rightDelimArg, delimsArg string
-var ignoreProjectOverrides bool
-var templateCmd = &cobra.Command{
-	Use:   "template [template]",
-	Short: "Execute a template",
-	Args:  cobra.MinimumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		var templateName = args[0]
-		projectContext, err := getProjectContext()
-		checkError(err)
+func newTemplateCmd(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
+	var templateOutput, leftDelimArg, rightDelimArg, delimsArg string
+	var ignoreProjectOverrides bool
 
-		namedArgs := map[string]string{}
-		for _, arg := range args[1:] {
-			parts := strings.SplitN(arg, "=", 2)
-			namedArgs[parts[0]] = parts[1]
-		}
+	templateCmd := &cobra.Command{
+		Use:   "template [template]",
+		Short: "Execute a template",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var templateName = args[0]
+			projectContext, err := contextProvider()
+			checkError(uii, err)
 
-		planPaths := []string{
-			path.Join(projectContext.LocalPlanPath, "templates", templateName),
-			path.Join(projectContext.LocalPlanPath, templateName),
-		}
-
-		projectPaths := []string{
-			path.Join(projectContext.ProjectPath, "templates", templateName),
-			path.Join(projectContext.ProjectPath, templateName),
-		}
-
-		var paths []string
-		if ignoreProjectOverrides {
-			paths = planPaths
-		} else {
-			paths = append(projectPaths, planPaths...)
-		}
-
-		templatePath := resolveFirstPath(paths)
-		if templatePath == "" {
-			return fmt.Errorf("template `%s` not found", templateName)
-		}
-
-		leftDelim, rightDelim, err := parseDelims(leftDelimArg, rightDelimArg, delimsArg)
-		if err != nil {
-			return err
-		}
-
-		tmpl, err := template.New(templateName).Delims(leftDelim, rightDelim).Funcs(tmplFuncs.GetFuncMap()).ParseFiles(templatePath)
-		if err != nil {
-			uii.Errorln("Parse template file failed\nFile: %s", templatePath)
-			return err
-		}
-
-		context := context{
-			Args:        namedArgs,
-			Vars:        projectContext.Config.Variables,
-			PlanPath:    projectContext.LocalPlanPath,
-			ProjectPath: projectContext.ProjectPath,
-		}
-		var output io.Writer
-		if templateOutput == "" {
-			output = cmd.OutOrStdout()
-		} else {
-			// TODO: This is probably not the right place to initialize the temp dir?
-			os.MkdirAll(projectContext.TempDirectoryPath, os.ModePerm)
-			templateOutputPath := path.Join(projectContext.TempDirectoryPath, templateOutput)
-			file, err := os.Create(templateOutputPath)
-			if err != nil {
-				return errors.WithMessagef(err, "create template output file '%s'", templateOutputPath)
+			namedArgs := map[string]string{}
+			for _, arg := range args[1:] {
+				parts := strings.SplitN(arg, "=", 2)
+				namedArgs[parts[0]] = parts[1]
 			}
-			output = file
-		}
 
-		err = tmpl.ExecuteTemplate(output, path.Base(templatePath), context)
-		if err != nil {
-			uii.Errorln("Failed to execute template\nPlan: %s\nProject: %s", context.PlanPath, context.ProjectPath)
-			return err
-		}
-		return nil
-	},
-}
+			planPaths := []string{
+				path.Join(projectContext.LocalPlanPath, "templates", templateName),
+				path.Join(projectContext.LocalPlanPath, templateName),
+			}
 
-func init() {
+			projectPaths := []string{
+				path.Join(projectContext.ProjectPath, "templates", templateName),
+				path.Join(projectContext.ProjectPath, templateName),
+			}
+
+			var paths []string
+			if ignoreProjectOverrides {
+				paths = planPaths
+			} else {
+				paths = append(projectPaths, planPaths...)
+			}
+
+			templatePath := resolveFirstPath(paths)
+			if templatePath == "" {
+				return fmt.Errorf("template `%s` not found", templateName)
+			}
+
+			leftDelim, rightDelim, err := parseDelims(leftDelimArg, rightDelimArg, delimsArg)
+			if err != nil {
+				return err
+			}
+
+			tmpl, err := template.New(templateName).Delims(leftDelim, rightDelim).Funcs(tmplFuncs.GetFuncMap()).ParseFiles(templatePath)
+			if err != nil {
+				uii.Errorln("Parse template file failed\nFile: %s", templatePath)
+				return err
+			}
+
+			context := context{
+				Args:        namedArgs,
+				Vars:        projectContext.Config.Variables,
+				PlanPath:    projectContext.LocalPlanPath,
+				ProjectPath: projectContext.ProjectPath,
+			}
+			var output io.Writer
+			if templateOutput == "" {
+				output = cmd.OutOrStdout()
+			} else {
+				// TODO: This is probably not the right place to initialize the temp dir?
+				os.MkdirAll(projectContext.TempDirectoryPath, os.ModePerm)
+				templateOutputPath := path.Join(projectContext.TempDirectoryPath, templateOutput)
+				file, err := os.Create(templateOutputPath)
+				if err != nil {
+					return errors.WithMessagef(err, "create template output file '%s'", templateOutputPath)
+				}
+				output = file
+			}
+
+			err = tmpl.ExecuteTemplate(output, path.Base(templatePath), context)
+			if err != nil {
+				uii.Errorln("Failed to execute template\nPlan: %s\nProject: %s", context.PlanPath, context.ProjectPath)
+				return err
+			}
+			return nil
+		},
+	}
+
 	templateCmd.Flags().StringVarP(&templateOutput, "output", "o", "", "Select filename to output file to in temporary directory")
 	templateCmd.Flags().StringVarP(&delimsArg, "delims", "", "", "Select delims for templating. Split by ','. If ',' is in the delims, then use --left-delim and --right-delim instead")
 	templateCmd.Flags().StringVarP(&leftDelimArg, "left-delim", "", "", "Select delims for templating. Defaults to '{{'")
 	templateCmd.Flags().StringVarP(&rightDelimArg, "right-delim", "", "", "Select delims for templating. Defaults to '}}'")
 	templateCmd.Flags().BoolVarP(&ignoreProjectOverrides, "ignore-project-overrides", "", false, "Set flag to ignore template files located in the project folder")
-	rootCmd.AddCommand(templateCmd)
+
+	return templateCmd
 }
 
 func resolveFirstPath(paths []string) string {

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -21,7 +21,7 @@ type context struct {
 	ProjectPath string
 }
 
-func newTemplateCmd(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
+func newTemplate(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 	var templateOutput, leftDelimArg, rightDelimArg, delimsArg string
 	var ignoreProjectOverrides bool
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -21,6 +21,7 @@ func executeTestCases(t *testing.T, testCases []testCase) {
 			stdBuf := new(bytes.Buffer)
 			errBuf := new(bytes.Buffer)
 
+			rootCmd := initializedRoot()
 			rootCmd.SetOut(stdBuf)
 			rootCmd.SetErr(errBuf)
 			rootCmd.SetArgs(tc.input)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newVersionCmd(uii *ui.UI) *cobra.Command {
+func newVersion(uii *ui.UI) *cobra.Command {
 	var showCommit bool
 
 	versionCmd := &cobra.Command{

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,13 +7,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	showCommit bool
-	versionCmd = &cobra.Command{
+func newVersionCmd(uii *ui.UI) *cobra.Command {
+	var showCommit bool
+
+	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "Info about version of shuttle",
 		Run: func(cmd *cobra.Command, args []string) {
-			uii = uii.SetContext(ui.LevelSilent)
+			*uii = uii.SetContext(ui.LevelSilent)
 			if showCommit {
 				fmt.Println(commit)
 			} else {
@@ -21,9 +22,8 @@ var (
 			}
 		},
 	}
-)
 
-func init() {
 	versionCmd.Flags().BoolVar(&showCommit, "commit", false, "Get git commit sha for current version")
-	rootCmd.AddCommand(versionCmd)
+
+	return versionCmd
 }


### PR DESCRIPTION
Currently all the cobra commands are stored with a global state making
dependencies and order of execution impossible to understand.

This change adds constructors to all commands with arguments for dependencies
unwrapping the global state.

The change is motivated by spurious test failures depending on what order they
are run in. Further more it is a general quiality enhancement of the code base
leading the way for more general refactors.