### PR TITLE
Run all tests in test-go

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -87,7 +87,7 @@ projects no matter what technologies the project is using.
 Read more about shuttle at https://github.com/lunarway/shuttle`, version),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if verboseFlag {
-				*uii = uii.SetUserLevel(ui.LevelVerbose)
+				uii.SetUserLevel(ui.LevelVerbose)
 			}
 			uii.Verboseln("Running shuttle")
 			uii.Verboseln("- version: %s", version)
@@ -125,23 +125,23 @@ func Execute(out, err io.Writer) {
 func initializedRoot(out, err io.Writer) (*cobra.Command, *ui.UI) {
 	uii := ui.Create(out, err)
 
-	rootCmd, ctxProvider := newRoot(&uii)
+	rootCmd, ctxProvider := newRoot(uii)
 	rootCmd.SetOut(out)
 	rootCmd.SetErr(err)
 
-	rootCmd.AddCommand(newDocumentation(&uii, ctxProvider))
-	rootCmd.AddCommand(newCompletion(&uii))
-	rootCmd.AddCommand(newGet(&uii, ctxProvider))
-	rootCmd.AddCommand(newGitPlan(&uii, ctxProvider))
-	rootCmd.AddCommand(newHas(&uii, ctxProvider))
-	rootCmd.AddCommand(newLs(&uii, ctxProvider))
-	rootCmd.AddCommand(newPlan(&uii, ctxProvider))
-	rootCmd.AddCommand(newPrepare(&uii, ctxProvider))
-	rootCmd.AddCommand(newRun(&uii, ctxProvider))
-	rootCmd.AddCommand(newTemplate(&uii, ctxProvider))
-	rootCmd.AddCommand(newVersion(&uii))
+	rootCmd.AddCommand(newDocumentation(uii, ctxProvider))
+	rootCmd.AddCommand(newCompletion(uii))
+	rootCmd.AddCommand(newGet(uii, ctxProvider))
+	rootCmd.AddCommand(newGitPlan(uii, ctxProvider))
+	rootCmd.AddCommand(newHas(uii, ctxProvider))
+	rootCmd.AddCommand(newLs(uii, ctxProvider))
+	rootCmd.AddCommand(newPlan(uii, ctxProvider))
+	rootCmd.AddCommand(newPrepare(uii, ctxProvider))
+	rootCmd.AddCommand(newRun(uii, ctxProvider))
+	rootCmd.AddCommand(newTemplate(uii, ctxProvider))
+	rootCmd.AddCommand(newVersion(uii))
 
-	return rootCmd, &uii
+	return rootCmd, uii
 }
 
 type contextProvider func() (config.ShuttleProjectContext, error)
@@ -170,7 +170,7 @@ func getProjectContext(rootCmd *cobra.Command, uii *ui.UI, projectPath string, c
 	}
 
 	var c config.ShuttleProjectContext
-	_, err = c.Setup(fullProjectPath, *uii, clean, skipGitPlanPulling, plan, projectFlagSet)
+	_, err = c.Setup(fullProjectPath, uii, clean, skipGitPlanPulling, plan, projectFlagSet)
 	if err != nil {
 		return config.ShuttleProjectContext{}, err
 	}

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -81,7 +81,7 @@ Installing bash completion on Linux
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			*uii = uii.SetContext(ui.LevelSilent)
+			uii.SetContext(ui.LevelSilent)
 			switch args[0] {
 			case "zsh":
 				runCompletionZsh(cmd.OutOrStdout(), cmd.Root())

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -21,7 +21,7 @@ func newGet(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		//Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			*uii = uii.SetContext(ui.LevelError)
+			uii.SetContext(ui.LevelError)
 			context, err := contextProvider()
 			checkError(uii, err)
 			path := args[0]

--- a/cmd/has.go
+++ b/cmd/has.go
@@ -23,7 +23,7 @@ func newHas(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 		SilenceErrors: true,
 		//Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			*uii = uii.SetContext(ui.LevelSilent)
+			uii.SetContext(ui.LevelSilent)
 
 			context, err := contextProvider()
 			checkError(uii, err)

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -42,7 +42,7 @@ Available fields are:
 				ProjectPath       string
 				TempDirectoryPath string
 			}
-			*uii = uii.SetUserLevel(ui.LevelError)
+			uii.SetUserLevel(ui.LevelError)
 			context, err := contextProvider()
 			checkError(uii, err)
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -11,7 +11,7 @@ func TestRoot(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:      "test moonbase build",
-			input:     strings("-v", "-p", "../examples/no-plan-project", "run", "hello"),
+			input:     strings("-p", "../examples/no-plan-project", "run", "hello"),
 			stdoutput: "Hello no plan project\n",
 			erroutput: "",
 			err:       nil,

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -11,7 +11,7 @@ func TestRoot(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:      "test moonbase build",
-			input:     strings("-p", "../examples/no-plan-project", "run", "hello"),
+			input:     strings("-v", "-p", "../examples/no-plan-project", "run", "hello"),
 			stdoutput: "Hello no plan project\n",
 			erroutput: "",
 			err:       nil,

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -32,6 +32,8 @@ func executeTestCases(t *testing.T, testCases []testCase) {
 			}
 			assert.Equal(t, tc.stdoutput, stdBuf.String())
 			assert.Equal(t, tc.erroutput, errBuf.String())
+			t.Logf("STDOUT: %s", stdBuf.String())
+			t.Logf("ERROUT: %s", errBuf.String())
 		})
 	}
 }

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -21,9 +21,7 @@ func executeTestCases(t *testing.T, testCases []testCase) {
 			stdBuf := new(bytes.Buffer)
 			errBuf := new(bytes.Buffer)
 
-			rootCmd := initializedRoot()
-			rootCmd.SetOut(stdBuf)
-			rootCmd.SetErr(errBuf)
+			rootCmd, _ := initializedRoot(stdBuf, errBuf)
 			rootCmd.SetArgs(tc.input)
 
 			err := rootCmd.Execute()

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -14,7 +14,7 @@ func newVersion(uii *ui.UI) *cobra.Command {
 		Use:   "version",
 		Short: "Info about version of shuttle",
 		Run: func(cmd *cobra.Command, args []string) {
-			*uii = uii.SetContext(ui.LevelSilent)
+			uii.SetContext(ui.LevelSilent)
 			if showCommit {
 				fmt.Println(commit)
 			} else {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/cli/safeexec v1.0.0
-	github.com/go-cmd/cmd v1.4.0
+	github.com/go-cmd/cmd v1.4.1
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/mitchellh/copystructure v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-cmd/cmd v1.4.0 h1:dF+1JtZMlgCKAcsvstp2VNmVA/jXRjlRYFOF4/w7Bbo=
 github.com/go-cmd/cmd v1.4.0/go.mod h1:tbBenttXtZU4c5djS1o7PWL5pd2xAr5sIqH1kGdNiRc=
+github.com/go-cmd/cmd v1.4.1 h1:JUcEIE84v8DSy02XTZpUDeGKExk2oW3DA10hTjbQwmc=
+github.com/go-cmd/cmd v1.4.1/go.mod h1:tbBenttXtZU4c5djS1o7PWL5pd2xAr5sIqH1kGdNiRc=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/main.go
+++ b/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"os"
+
 	"github.com/lunarway/shuttle/cmd"
 )
 
 func main() {
-	cmd.Execute()
+	cmd.Execute(os.Stdout, os.Stderr)
 }

--- a/pkg/config/shuttleconfig.go
+++ b/pkg/config/shuttleconfig.go
@@ -32,11 +32,11 @@ type ShuttleProjectContext struct {
 	LocalPlanPath             string
 	Plan                      ShuttlePlanConfiguration
 	Scripts                   map[string]ShuttlePlanScript
-	UI                        ui.UI
+	UI                        *ui.UI
 }
 
 // Setup the ShuttleProjectContext for a specific path
-func (c *ShuttleProjectContext) Setup(projectPath string, uii ui.UI, clean bool, skipGitPlanPulling bool, planArgument string, strictConfigLookup bool) (*ShuttleProjectContext, error) {
+func (c *ShuttleProjectContext) Setup(projectPath string, uii *ui.UI, clean bool, skipGitPlanPulling bool, planArgument string, strictConfigLookup bool) (*ShuttleProjectContext, error) {
 	projectPath, err := c.Config.getConf(projectPath, strictConfigLookup)
 	if err != nil {
 		return nil, err

--- a/pkg/config/shuttleplan.go
+++ b/pkg/config/shuttleplan.go
@@ -85,7 +85,7 @@ func (p *ShuttlePlanConfiguration) Load(planPath string) (*ShuttlePlanConfigurat
 }
 
 // FetchPlan so it exists locally and return path to that plan
-func FetchPlan(plan string, projectPath string, localShuttleDirectoryPath string, uii ui.UI, skipGitPlanPulling bool, planArgument string) (string, error) {
+func FetchPlan(plan string, projectPath string, localShuttleDirectoryPath string, uii *ui.UI, skipGitPlanPulling bool, planArgument string) (string, error) {
 	if isPlanArgumentAPlan(planArgument) {
 		uii.Infoln("Using overloaded plan %v", planArgument)
 		return FetchPlan(getPlanFromPlanArgument(planArgument), projectPath, localShuttleDirectoryPath, uii, skipGitPlanPulling, "")

--- a/pkg/executors/executor_test.go
+++ b/pkg/executors/executor_test.go
@@ -212,16 +212,20 @@ func TestExecute_contextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		// let the container start before stopping it
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(1 * time.Second)
+		t.Log("Cancelling context")
 		cancel()
 	}()
 
+	t.Log("Executing script")
 	err := Execute(ctx, projectContext, "serve", nil, true)
 	assert.EqualError(t, err, context.Canceled.Error())
 
+	t.Log("Waiting for container to start")
 	// sadly we need to give the docker some time before "docker ps" shows the
 	// containers
 	time.Sleep(500 * time.Millisecond)
+	t.Log("Checking of container is still running")
 	images := runningDockerImages(t, imageName)
 	assert.Len(t, images, 0, "expected no images to be running")
 }

--- a/pkg/executors/executor_test.go
+++ b/pkg/executors/executor_test.go
@@ -1,6 +1,7 @@
 package executors
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"testing"
@@ -160,7 +161,7 @@ func TestExecute(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			verboseUI := ui.Create()
+			verboseUI := ui.Create(&bytes.Buffer{}, &bytes.Buffer{})
 			verboseUI.SetUserLevel(ui.LevelVerbose)
 
 			err := Execute(context.Background(), config.ShuttleProjectContext{
@@ -191,7 +192,7 @@ func TestExecute(t *testing.T) {
 func TestExecute_contextCancellation(t *testing.T) {
 	imageName := fmt.Sprintf("shuttle-test-execute-cancellation-%d", time.Now().UnixNano())
 	t.Logf("Starting image %s", imageName)
-	verboseUI := ui.Create()
+	verboseUI := ui.Create(&bytes.Buffer{}, &bytes.Buffer{})
 	verboseUI.SetUserLevel(ui.LevelVerbose)
 	projectContext := config.ShuttleProjectContext{
 		UI: verboseUI,

--- a/pkg/executors/shell.go
+++ b/pkg/executors/shell.go
@@ -52,14 +52,12 @@ func executeShell(ctx context.Context, context ActionExecutionContext) error {
 	// for the stdout and stderr streams to be read but to be sure that the
 	// execution does not move on before our scanner Go routines have returned we
 	// add this wait.
-	defer func() {
-		wg.Wait()
-		// Do we actually see a race here????
-		time.Sleep(1 * time.Second)
-	}()
+	defer wg.Wait()
 
 	go stdScanner(&wg, stderr, context.ScriptContext.Project.UI.Errorln)
 	go stdScanner(&wg, stdout, context.ScriptContext.Project.UI.Infoln)
+
+	wg.Wait()
 
 	err = waitOrStop(ctx, execCmd, 5*time.Second)
 	if err != nil {

--- a/pkg/executors/shell.go
+++ b/pkg/executors/shell.go
@@ -55,7 +55,7 @@ func executeShell(ctx context.Context, context ActionExecutionContext) error {
 	defer func() {
 		wg.Wait()
 		// Do we actually see a race here????
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(1 * time.Second)
 	}()
 
 	go stdScanner(&wg, stderr, context.ScriptContext.Project.UI.Errorln)

--- a/pkg/executors/shell.go
+++ b/pkg/executors/shell.go
@@ -52,11 +52,7 @@ func executeShell(ctx context.Context, context ActionExecutionContext) error {
 	// for the stdout and stderr streams to be read but to be sure that the
 	// execution does not move on before our scanner Go routines have returned we
 	// add this wait.
-	defer func() {
-		wg.Wait()
-		// Do we actually see a race here????
-		time.Sleep(1 * time.Second)
-	}()
+	defer wg.Wait()
 
 	go stdScanner(&wg, stderr, context.ScriptContext.Project.UI.Errorln)
 	go stdScanner(&wg, stdout, context.ScriptContext.Project.UI.Infoln)

--- a/pkg/executors/shell.go
+++ b/pkg/executors/shell.go
@@ -52,7 +52,11 @@ func executeShell(ctx context.Context, context ActionExecutionContext) error {
 	// for the stdout and stderr streams to be read but to be sure that the
 	// execution does not move on before our scanner Go routines have returned we
 	// add this wait.
-	defer wg.Wait()
+	defer func() {
+		wg.Wait()
+		// Do we actually see a race here????
+		time.Sleep(100 * time.Millisecond)
+	}()
 
 	go stdScanner(&wg, stderr, context.ScriptContext.Project.UI.Errorln)
 	go stdScanner(&wg, stdout, context.ScriptContext.Project.UI.Infoln)

--- a/pkg/executors/shell.go
+++ b/pkg/executors/shell.go
@@ -1,153 +1,84 @@
 package executors
 
 import (
-	"bufio"
 	"context"
-	"errors"
-	"fmt"
-	"io"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"sync"
-	"syscall"
-	"time"
 
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-cmd/cmd"
 	"github.com/lunarway/shuttle/pkg/config"
-	shuttleerrors "github.com/lunarway/shuttle/pkg/errors"
+	"github.com/lunarway/shuttle/pkg/errors"
 )
 
 // Build builds the docker image from a shuttle plan
 func executeShell(ctx context.Context, context ActionExecutionContext) error {
-	execCmd := exec.Command("sh", "-c", fmt.Sprintf("cd '%s'; %s", context.ScriptContext.Project.ProjectPath, context.Action.Shell))
-	context.ScriptContext.Project.UI.Verboseln("Starting shell command: %+v", execCmd.String())
+	cmdOptions := cmd.Options{
+		Buffered:  false,
+		Streaming: true,
+		// support large outputs from scripts
+		LineBufferSize: 512e3,
+	}
+
+	cmdArgs := []string{"-c", fmt.Sprintf("cd '%s'; %s", context.ScriptContext.Project.ProjectPath, context.Action.Shell)}
+	execCmd := cmd.NewCmdOptions(cmdOptions, "sh", cmdArgs...)
+	context.ScriptContext.Project.UI.Verboseln("Starting shell command: %s %s", execCmd.Name, strings.Join(cmdArgs, " "))
 
 	setupCommandEnvironmentVariables(execCmd, context)
 
-	stdout, err := execCmd.StdoutPipe()
-	if err != nil {
-		return fmt.Errorf("get stdout pipe: %w", err)
-	}
-
-	stderr, err := execCmd.StderrPipe()
-	if err != nil {
-		return fmt.Errorf("get stderr pipe: %w", err)
-	}
-
-	// Set process group ID so the cmd and all its children become a new process
-	// group. This allows Stop to SIGTERM the cmd's process group without killing
-	// this process (i.e. this code here). Note that this does not support
-	// windows. this is copied from go-cmd:
-	// https://github.com/go-cmd/cmd/blob/9e40bcc1acc0e559af2c2e99ae5674ae25cde397/cmd_darwin.go#L15
-	execCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	outputReadCompleted := make(chan struct{})
 
 	go func() {
-		select {
-		case <-ctx.Done():
-			fmt.Println("Send interrupt to process")
-			err := execCmd.Process.Signal(os.Interrupt)
-			if err != nil {
-				fmt.Printf("Failed to signal process to stop: %v\n", err)
-			}
-		}
-	}()
+		defer close(outputReadCompleted)
 
-	fmt.Println("Starting process")
-	err = execCmd.Start()
-	if err != nil {
-		return fmt.Errorf("start command: %w", err)
-	}
-
-	// unusual use of sync.WaitGroup here. The os/exec.Cmd#Wait must not be called
-	// before the stdout and stderr streams are closed. Because of this we wait
-	// for the scanner Go routines to complete before moving on to waiting on the
-	// command.
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go stdScanner(&wg, stderr, context.ScriptContext.Project.UI.Errorln)
-	go stdScanner(&wg, stdout, context.ScriptContext.Project.UI.Infoln)
-	fmt.Println("Waiting for scanners")
-	wg.Wait()
-
-	err = waitOrStop(ctx, execCmd, 10*time.Second)
-	if err != nil {
-		var exitError *exec.ExitError
-		if errors.As(err, &exitError) {
-			exitCode := exitError.ExitCode()
-			if exitCode > 0 {
-				return shuttleerrors.NewExitCode(4, "Failed executing script `%s`: shell script `%s`\nExit code: %v", context.ScriptContext.ScriptName, context.Action.Shell, exitCode)
-			}
-		}
-		return err
-	}
-
-	return nil
-}
-
-// waitOrStop waits for the already-started command cmd by calling its Wait
-// method.
-//
-// If cmd does not return before ctx is done, waitOrStop sends it the given
-// interrupt signal. If killDelay is positive, waitOrStop waits that additional
-// period for Wait to return before sending os.Kill.
-//
-// This function is inspired by
-// https://github.com/golang/go/blob/cacac8bdc5c93e7bc71df71981fdf32dded017bf/src/cmd/go/script_test.go#L1091
-// and adapted to a non-test context along with handling group termination.
-func waitOrStop(ctx context.Context, cmd *exec.Cmd, killDelay time.Duration) error {
-	interruptChan := make(chan error)
-	go func() {
-		select {
-		case interruptChan <- nil:
-			return
-		case <-ctx.Done():
-		}
-
-		// Signal the process group (-pid), not just the process, so that the
-		// process and all its children are signaled. Else, child procs can keep
-		// running and keep the stdout/stderr fd open and cause cmd.Wait to hang.
-		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
-		if err == nil {
-			err = ctx.Err() // Report ctx.Err() as the reason we interrupted.
-		} else if err.Error() == "os: process already finished" {
-			interruptChan <- nil
-			return
-		}
-
-		if killDelay > 0 {
-			timer := time.NewTimer(killDelay)
+		for execCmd.Stdout != nil || execCmd.Stderr != nil {
 			select {
-			// Report ctx.Err() as the reason we interrupted the process...
-			case interruptChan <- ctx.Err():
-				timer.Stop()
-				return
-			// ...but after killDelay has elapsed, fall back to a stronger signal.
-			case <-timer.C:
+			case line, open := <-execCmd.Stdout:
+				if !open {
+					execCmd.Stdout = nil
+					continue
+				}
+				context.ScriptContext.Project.UI.Infoln("%s", line)
+			case line, open := <-execCmd.Stderr:
+				if !open {
+					execCmd.Stderr = nil
+					continue
+				}
+				context.ScriptContext.Project.UI.Errorln("%s", line)
 			}
-
-			// Wait still hasn't returned.
-			// Kill the process harder to make sure that it exits.
-			//
-			// Ignore any error: if cmd.Process has already terminated, we still
-			// want to send ctx.Err() (or the error from the Interrupt call)
-			// to properly attribute the signal that may have terminated it.
-			_ = cmd.Process.Kill()
 		}
-
-		interruptChan <- err
 	}()
 
-	waitErr := cmd.Wait()
+	// Run and wait for Cmd to return, discard Status
+	context.ScriptContext.Project.UI.Titleln("shell: %s", context.Action.Shell)
 
-	interruptErr := <-interruptChan
-	if interruptErr != nil {
-		return interruptErr
+	// stop cmd if context is cancelled
+	go func() {
+		select {
+		case <-ctx.Done():
+			err := execCmd.Stop()
+			if err != nil {
+				context.ScriptContext.Project.UI.Errorln("Failed to stop script '%s': %v", context.Action.Shell, err)
+			}
+		case <-outputReadCompleted:
+		}
+	}()
+
+	select {
+	case status := <-execCmd.Start():
+		<-outputReadCompleted
+		if status.Exit > 0 {
+			return errors.NewExitCode(4, "Failed executing script `%s`: shell script `%s`\nExit code: %v", context.ScriptContext.ScriptName, context.Action.Shell, status.Exit)
+		}
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
-
-	return waitErr
 }
 
-func setupCommandEnvironmentVariables(execCmd *exec.Cmd, context ActionExecutionContext) {
+func setupCommandEnvironmentVariables(execCmd *cmd.Cmd, context ActionExecutionContext) {
 	shuttlePath, _ := filepath.Abs(filepath.Dir(os.Args[0]))
 
 	execCmd.Env = os.Environ()
@@ -160,23 +91,6 @@ func setupCommandEnvironmentVariables(execCmd *exec.Cmd, context ActionExecution
 	// TODO: Add project path as a shuttle specific ENV
 	execCmd.Env = append(execCmd.Env, fmt.Sprintf("PATH=%s", shuttlePath+string(os.PathListSeparator)+os.Getenv("PATH")))
 	execCmd.Env = append(execCmd.Env, fmt.Sprintf("SHUTTLE_PLANS_ALREADY_VALIDATED=%s", context.ScriptContext.Project.LocalPlanPath))
-}
-
-func stdScanner(wg *sync.WaitGroup, reader io.ReadCloser, output func(format string, args ...interface{})) {
-	defer wg.Done()
-
-	scanner := bufio.NewScanner(reader)
-
-	// increase max line capacity of the buffer to allow for reading very long
-	// lines. This sets the maximum to 512k characters per line.
-	const maxCapacity = 512 * 1024
-	buf := make([]byte, maxCapacity)
-	scanner.Buffer(buf, maxCapacity)
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		output("%s", line)
-	}
 }
 
 func init() {

--- a/pkg/executors/shell.go
+++ b/pkg/executors/shell.go
@@ -51,9 +51,6 @@ func executeShell(ctx context.Context, context ActionExecutionContext) error {
 		}
 	}()
 
-	// Run and wait for Cmd to return, discard Status
-	context.ScriptContext.Project.UI.Titleln("shell: %s", context.Action.Shell)
-
 	// stop cmd if context is cancelled
 	go func() {
 		select {

--- a/pkg/executors/shell.go
+++ b/pkg/executors/shell.go
@@ -52,7 +52,11 @@ func executeShell(ctx context.Context, context ActionExecutionContext) error {
 	// for the stdout and stderr streams to be read but to be sure that the
 	// execution does not move on before our scanner Go routines have returned we
 	// add this wait.
-	defer wg.Wait()
+	defer func() {
+		wg.Wait()
+		// Do we actually see a race here????
+		time.Sleep(1 * time.Second)
+	}()
 
 	go stdScanner(&wg, stderr, context.ScriptContext.Project.UI.Errorln)
 	go stdScanner(&wg, stdout, context.ScriptContext.Project.UI.Infoln)

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -70,7 +70,7 @@ func IsPlan(plan string) bool {
 }
 
 // GetGitPlan will pull git repository and return its path
-func GetGitPlan(plan string, localShuttleDirectoryPath string, uii ui.UI, skipGitPlanPulling bool, planArgument string) (string, error) {
+func GetGitPlan(plan string, localShuttleDirectoryPath string, uii *ui.UI, skipGitPlanPulling bool, planArgument string) (string, error) {
 	parsedGitPlan := ParsePlan(plan)
 
 	if strings.HasPrefix(planArgument, "#") {
@@ -148,7 +148,7 @@ func GetGitPlan(plan string, localShuttleDirectoryPath string, uii ui.UI, skipGi
 	return planPath, nil
 }
 
-func RunGitPlanCommand(command string, plan string, uii ui.UI) {
+func RunGitPlanCommand(command string, plan string, uii *ui.UI) {
 
 	cmdOptions := go_cmd.Options{
 		Buffered:  false,
@@ -211,7 +211,7 @@ func expandHome(path string) string {
 	return strings.Replace(path, "~/", usr.HomeDir+"/", 1)
 }
 
-func gitCmd(command string, dir string, uii ui.UI) error {
+func gitCmd(command string, dir string, uii *ui.UI) error {
 	cmdOptions := go_cmd.Options{
 		Buffered:  true,
 		Streaming: true,

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -16,8 +16,8 @@ type UI struct {
 }
 
 // Create doc
-func Create(out, err io.Writer) UI {
-	return UI{
+func Create(out, err io.Writer) *UI {
+	return &UI{
 		EffectiveLevel: LevelInfo,
 		DefaultLevel:   LevelInfo,
 		UserLevelSet:   false,
@@ -27,34 +27,23 @@ func Create(out, err io.Writer) UI {
 }
 
 // SetUserLevel doc
-func (ui *UI) SetUserLevel(level Level) UI {
-	return UI{
-		EffectiveLevel: level,
-		DefaultLevel:   ui.DefaultLevel,
-		UserLevel:      level,
-		UserLevelSet:   true,
-		Out:            ui.Out,
-		Err:            ui.Err,
-	}
+func (ui *UI) SetUserLevel(level Level) *UI {
+	ui.EffectiveLevel = level
+	ui.UserLevel = level
+	ui.UserLevelSet = true
+	return ui
 }
 
 // SetContext doc
-func (ui *UI) SetContext(level Level) UI {
-	var effectiveLevel Level
+func (ui *UI) SetContext(level Level) *UI {
 	if ui.UserLevelSet {
-		effectiveLevel = ui.UserLevel
+		ui.EffectiveLevel = ui.UserLevel
 	} else {
-		effectiveLevel = level
+		ui.EffectiveLevel = level
 	}
+	ui.DefaultLevel = level
 
-	return UI{
-		EffectiveLevel: effectiveLevel,
-		DefaultLevel:   level,
-		UserLevel:      ui.UserLevel,
-		UserLevelSet:   ui.UserLevelSet,
-		Out:            ui.Out,
-		Err:            ui.Err,
-	}
+	return ui
 }
 
 // Verboseln prints a formatted verbose message line.

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -3,7 +3,6 @@ package ui
 import (
 	"fmt"
 	"io"
-	"os"
 )
 
 // UI is the abstraction of handling terminal output for shuttle
@@ -17,19 +16,14 @@ type UI struct {
 }
 
 // Create doc
-func Create() UI {
+func Create(out, err io.Writer) UI {
 	return UI{
 		EffectiveLevel: LevelInfo,
 		DefaultLevel:   LevelInfo,
 		UserLevelSet:   false,
-		Out:            os.Stdout,
-		Err:            os.Stderr,
+		Out:            out,
+		Err:            err,
 	}
-}
-
-func (ui *UI) SetOutput(out io.Writer, err io.Writer) {
-	ui.Out = out
-	ui.Err = err
 }
 
 // SetUserLevel doc

--- a/shuttle.yaml
+++ b/shuttle.yaml
@@ -7,7 +7,7 @@ scripts:
   test-go:
     description: 'run tests written in go'
     actions:
-    - shell: go test -v ./pkg/... -run Test*
+    - shell: go test -v ./...
   test-shell:
     description: 'run tests written in shell'
     actions:


### PR DESCRIPTION
Currently only Go tests in package pkg is tested in the test-go script. This
means the command accept tests in package cmd is not run.

This change fixes that.