### PR TITLE
Remove os.Exit from commands

### DIFF
--- a/cmd/documentation.go
+++ b/cmd/documentation.go
@@ -21,21 +21,30 @@ Usually this will target a hosted git repository, eg. GitHub README.
 The application to open the documentation is inferred from the operating system
 and respects the BROWSER environment variable.`,
 		Args: cobra.ExactArgs(0),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			context, err := contextProvider()
-			checkError(uii, err)
+			if err != nil {
+				return err
+			}
 
 			url, err := context.DocumentationURL()
-			checkError(uii, err)
+			if err != nil {
+				return err
+			}
+
 			uii.Infoln("Documentation available at: %s", url)
 
 			browseCmd, err := browser.Command(url, cmd.ErrOrStderr())
-			checkError(uii, err)
+			if err != nil {
+				return err
+			}
 
 			err = browseCmd.Run()
 			if err != nil {
-				checkError(uii, errors.NewExitCode(1, "Failed to open document reference: %v", err))
+				return errors.NewExitCode(1, "Failed to open document reference: %v", err)
 			}
+
+			return nil
 		},
 	}
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -19,11 +19,13 @@ func newGet(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 		Use:   "get [variable]",
 		Short: "Get a variable value",
 		Args:  cobra.ExactArgs(1),
-		//Long:  ``,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			*uii = uii.SetContext(ui.LevelError)
 			context, err := contextProvider()
-			checkError(uii, err)
+			if err != nil {
+				return err
+			}
+
 			path := args[0]
 			var templ string
 			if getFlagTemplate != "" {
@@ -32,8 +34,11 @@ func newGet(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 			value := templates.TmplGet(path, context.Config.Variables)
 			if templ != "" {
 				err := ui.Template(cmd.OutOrStdout(), "get", templ, value)
-				checkError(uii, err)
-				return
+				if err != nil {
+					return err
+				}
+
+				return nil
 			}
 			switch value.(type) {
 			case nil:
@@ -41,10 +46,12 @@ func newGet(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 			default:
 				x, err := yaml.Marshal(value)
 				if err != nil {
-					checkError(uii, errors.NewExitCode(9, "Could not yaml encode value '%s'\nError: %s", value, err))
+					return errors.NewExitCode(9, "Could not yaml encode value '%s'\nError: %s", value, err)
 				}
 				fmt.Fprint(cmd.OutOrStdout(), strings.TrimRight(string(x), "\n"))
 			}
+
+			return nil
 		},
 	}
 

--- a/cmd/git-plan.go
+++ b/cmd/git-plan.go
@@ -12,12 +12,17 @@ func newGitPlan(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 	gitPlanCmd := &cobra.Command{
 		Use:   "git-plan [...git_args]",
 		Short: "Run a git command for the plan",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			// TODO: this is no longer possible to configure
 			// skipGitPlanPulling = true
 			context, err := contextProvider()
-			checkError(uii, err)
+			if err != nil {
+				return err
+			}
+
 			git.RunGitPlanCommand(strings.Join(args, " "), context.LocalPlanPath, context.UI)
+
+			return nil
 		},
 	}
 

--- a/cmd/has.go
+++ b/cmd/has.go
@@ -26,7 +26,9 @@ func newHas(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 			*uii = uii.SetContext(ui.LevelSilent)
 
 			context, err := contextProvider()
-			checkError(uii, err)
+			if err != nil {
+				return err
+			}
 
 			variable := args[0]
 

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -25,9 +25,11 @@ func newLs(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 	lsCmd := &cobra.Command{
 		Use:   "ls [command]",
 		Short: "List possible commands",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			context, err := contextProvider()
-			checkError(uii, err)
+			if err != nil {
+				return err
+			}
 
 			var templ string
 			if lsFlagTemplate != "" {
@@ -39,7 +41,11 @@ func newLs(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 				Scripts: context.Scripts,
 				Max:     calculateRightPadForKeys(context.Scripts),
 			})
-			checkError(uii, err)
+			if err != nil {
+				return err
+			}
+
+			return nil
 		},
 	}
 

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -34,7 +34,7 @@ Available fields are:
 		Example: `Get the raw plan string as it is written in the shuttle.yaml file:
   shuttle plan --template '{{.PlanRaw}}'`,
 		Args: cobra.ExactArgs(0),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			type templData struct {
 				LocalPlanPath     string
 				Plan              string
@@ -44,7 +44,9 @@ Available fields are:
 			}
 			*uii = uii.SetUserLevel(ui.LevelError)
 			context, err := contextProvider()
-			checkError(uii, err)
+			if err != nil {
+				return err
+			}
 
 			var templ string
 			if planFlagTemplate != "" {
@@ -59,7 +61,11 @@ Available fields are:
 				ProjectPath:       context.ProjectPath,
 				TempDirectoryPath: context.TempDirectoryPath,
 			})
-			checkError(uii, err)
+			if err != nil {
+				return err
+			}
+
+			return nil
 		},
 	}
 

--- a/cmd/prepare.go
+++ b/cmd/prepare.go
@@ -10,9 +10,13 @@ func newPrepare(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 		Use:   "prepare",
 		Short: "Load external resources",
 		Long:  `Load external resources as a preparation step, before starting to use shuttle`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			_, err := contextProvider()
-			checkError(uii, err)
+			if err != nil {
+				return err
+			}
+
+			return nil
 		},
 	}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -17,18 +17,27 @@ func newRun(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 	)
 
 	runCmd := &cobra.Command{
-		Use:   "run [command]",
-		Short: "Run a plan script",
-		Long:  `Specify which plan script to run`,
-		Args:  cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		Use:          "run [command]",
+		Short:        "Run a plan script",
+		Long:         `Specify which plan script to run`,
+		Args:         cobra.MinimumNArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var commandName = args[0]
 			context, err := contextProvider()
-			checkError(uii, err)
+			if err != nil {
+				return err
+			}
+
 			ctx, cancel := withSignal(stdcontext.Background(), uii)
 			defer cancel()
+
 			err = executors.Execute(ctx, context, commandName, args[1:], validateArgs)
-			checkError(uii, err)
+			if err != nil {
+				return err
+			}
+
+			return nil
 		},
 	}
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,20 +1,42 @@
 package cmd
 
 import (
+	"errors"
 	"testing"
 )
 
-func TestRoot(t *testing.T) {
+func TestRun(t *testing.T) {
 	strings := func(s ...string) []string {
 		return s
 	}
 	testCases := []testCase{
 		{
-			name:      "test moonbase build",
-			input:     strings("-p", "../examples/no-plan-project", "run", "hello"),
-			stdoutput: "Hello no plan project\n",
+			name:      "std out echo",
+			input:     strings("-p", "testdata/project", "run", "hello_stdout"),
+			stdoutput: "Hello stdout\n",
 			erroutput: "",
 			err:       nil,
+		},
+		{
+			name:      "std err echo",
+			input:     strings("-p", "testdata/project", "run", "hello_stderr"),
+			stdoutput: "",
+			erroutput: "\x1b[31;1mHello stderr\x1b[0m\n",
+			err:       nil,
+		},
+		{
+			name:      "exit 0",
+			input:     strings("-p", "testdata/project", "run", "exit_0"),
+			stdoutput: "",
+			erroutput: "",
+			err:       nil,
+		},
+		{
+			name:      "exit 1",
+			input:     strings("-p", "testdata/project", "run", "exit_1"),
+			stdoutput: "",
+			erroutput: "Error: exit code 4 - Failed executing script `exit_1`: shell script `exit 1`\nExit code: 1\n",
+			err:       errors.New("exit code 4 - Failed executing script `exit_1`: shell script `exit 1`\nExit code: 1"),
 		},
 	}
 	executeTestCases(t, testCases)

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -32,7 +32,9 @@ func newTemplate(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var templateName = args[0]
 			projectContext, err := contextProvider()
-			checkError(uii, err)
+			if err != nil {
+				return err
+			}
 
 			namedArgs := map[string]string{}
 			for _, arg := range args[1:] {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -30,10 +30,12 @@ func executeTestCases(t *testing.T, testCases []testCase) {
 			if tc.err == nil {
 				assert.NoError(t, err)
 			} else {
-				assert.EqualError(t, tc.err, err.Error())
+				assert.EqualError(t, err, tc.err.Error())
 			}
-			assert.Equal(t, tc.stdoutput, stdBuf.String())
-			assert.Equal(t, tc.erroutput, errBuf.String())
+			t.Logf("STDOUT: %s", stdBuf.String())
+			t.Logf("STDERR: %s", errBuf.String())
+			assert.Equal(t, tc.stdoutput, stdBuf.String(), "std output not as expected")
+			assert.Equal(t, tc.erroutput, errBuf.String(), "err output not as expected")
 		})
 	}
 }

--- a/cmd/testdata/project/shuttle.yaml
+++ b/cmd/testdata/project/shuttle.yaml
@@ -1,0 +1,14 @@
+plan: false
+scripts:
+  hello_stdout:
+    actions:
+      - shell: echo "Hello stdout"
+  hello_stderr:
+    actions:
+      - shell: '>&2 echo "Hello stderr"'
+  exit_0:
+    actions:
+      - shell: exit 0
+  exit_1:
+    actions:
+      - shell: exit 1


### PR DESCRIPTION
Currently the checkError function is used through out all the command's handlers
which makes them exit without cobra handling it. It also makes the commands very
hard to test.

As the root commands Execute already inspects the errors returned from
individual command handlers and also detects any ExitCode errors this change is
a noop. All handlers now return any error they encounter and let it be up to the
client of Execute to decide what to do with it.

Some tests of the behaviour is added to the command test suite with a new
dedicated test plan instead of the arbitrary projects and plans inside the
"examples" directory.