### PR TITLE
Migrate get accept tests from shunit2 to Go

### DIFF
--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -5,14 +5,32 @@ import (
 )
 
 func TestGet(t *testing.T) {
-	strings := func(s ...string) []string {
-		return s
-	}
 	testCases := []testCase{
 		{
-			name:      "get variable",
-			input:     strings("-p", "../examples/repo-project", "get", "docker.baseImage"),
-			stdoutput: "golang",
+			name:      "local plan",
+			input:     args("-p", "testdata/project", "get", "service"),
+			stdoutput: "shuttle",
+			erroutput: "",
+			err:       nil,
+		},
+		{
+			name:      "local plan with templating",
+			input:     args("-p", "testdata/project", "get", "nested", "--template", "{{ range $k, $v := . }}{{ $k }}{{ end }}"),
+			stdoutput: "subvar",
+			erroutput: "",
+			err:       nil,
+		},
+		{
+			name:      "local plan with templating function",
+			input:     args("-p", "testdata/project", "get", "nested", "--template", `{{ range objectArray "sub" . }}{{ .Key }}{{ end }}`),
+			stdoutput: "field",
+			erroutput: "",
+			err:       nil,
+		},
+		{
+			name:      "bool",
+			input:     args("-p", "testdata/project", "get", "boolVar"),
+			stdoutput: "false",
 			erroutput: "",
 			err:       nil,
 		},

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -7,6 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func args(s ...string) []string {
+	return s
+}
+
 type testCase struct {
 	name      string
 	input     []string

--- a/cmd/testdata/project/shuttle.yaml
+++ b/cmd/testdata/project/shuttle.yaml
@@ -1,4 +1,11 @@
 plan: false
+vars:
+  service: shuttle
+  boolVar: false
+  nested:
+    var: foo
+    sub:
+      field: baz
 scripts:
   hello_stdout:
     actions:

--- a/tests.sh
+++ b/tests.sh
@@ -35,21 +35,6 @@ function assertContains() {
 }
 
 
-test_can_get_variable_from_local_plan() {
-  result=$(./shuttle -p examples/moon-base get docker.image 2>&1)
-  assertEquals "earth-united/moon-base" "$result"
-}
-
-test_can_get_variable_from_local_plan_with_templating() {
-  result=$(./shuttle -p examples/moon-base get docker --template '{{ range $k, $v := . }}{{ $k }}{{ end }}' 2>&1)
-  assertEquals "image" "$result"
-}
-
-test_can_get_variable_from_local_plan_with_templating_functions() {
-  result=$(./shuttle -p examples/moon-base get env --template '{{ range objectArray "field" . }}{{ .Key }}{{ end }}' 2>&1)
-  assertEquals "key" "$result"
-}
-
 test_plan_from_relative_local_plan() {
   result=$(./shuttle -p examples/moon-base plan 2>&1)
   assertEquals "../station-plan" "$result"
@@ -75,11 +60,6 @@ test_plan_with_template_from_no_plan() {
   assertEquals "false" "$result"
 }
 
-test_can_get_variable_from_repo_plan() {
-  result=$(./shuttle -p examples/repo-project get docker.destImage 2>&1)
-  assertEquals "repo-project" "$result"
-}
-
 test_fails_getting_no_repo_plan() {
   assertErrorCode 4 -p examples/bad/no-repo-project ls
   assertContains "Failed executing git command \`clone" "$result"
@@ -88,13 +68,6 @@ test_fails_getting_no_repo_plan() {
 test_fails_loading_invalid_shuttle_configuration() {
   assertErrorCode 2 -p examples/bad/yaml-invalid ls
   assertContains "Failed to parse shuttle configuration" "$result"
-}
-
-test_get_a_boolean() {
-  result=$(./shuttle -p examples/moon-base get run-as-root 2>&1)
-  if [[ "$result" != "false" ]]; then
-    fail "Expected output to be 'false', but it was:\n$result"
-  fi
 }
 
 test_can_check_variable_exists() {


### PR DESCRIPTION
This change contains the migraiton of the get command's acceptance tests from
bash and shunit2 to Go.