### PR TITLE
Replace duplicate strings function with args func

### DIFF
--- a/cmd/has_test.go
+++ b/cmd/has_test.go
@@ -6,21 +6,17 @@ import (
 )
 
 func TestHas(t *testing.T) {
-	strings := func(s ...string) []string {
-		return s
-	}
-
 	testCases := []testCase{
 		{
 			name:      "has variable",
-			input:     strings("-p", "../examples/repo-project", "has", "docker.baseImage"),
+			input:     args("-p", "../examples/repo-project", "has", "docker.baseImage"),
 			stdoutput: "",
 			erroutput: "",
 			err:       nil,
 		},
 		{
 			name:      "has wrong argument switch",
-			input:     strings("-j", "../examples/repo-project", "has", "docker.baseImage"),
+			input:     args("-j", "../examples/repo-project", "has", "docker.baseImage"),
 			stdoutput: "",
 			erroutput: "",
 			err:       fmt.Errorf("unknown shorthand flag: 'j' in -j"),

--- a/cmd/ls_test.go
+++ b/cmd/ls_test.go
@@ -5,20 +5,17 @@ import (
 )
 
 func TestLs(t *testing.T) {
-	strings := func(s ...string) []string {
-		return s
-	}
 	testCases := []testCase{
 		{
 			name:      "list one action",
-			input:     strings("-p", "../examples/no-plan-project", "ls"),
+			input:     args("-p", "../examples/no-plan-project", "ls"),
 			stdoutput: "Available Scripts:\n  hello        \n",
 			erroutput: "",
 			err:       nil,
 		},
 		{
 			name:      "list actions",
-			input:     strings("-p", "../examples/repo-project/", "ls"),
+			input:     args("-p", "../examples/repo-project/", "ls"),
 			stdoutput: "Pulling latest plan changes on master\nAvailable Scripts:\n  build        Build the docker image\n  deploy       Deploys the image to a kubernetes environment\n  push         Push the docker image\n  say          Say something\n  test         Run test for the project\n",
 			erroutput: "",
 			err:       nil,

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -42,49 +42,45 @@ func TestRun(t *testing.T) {
 		removeShuttleDirectories(t, pwd)
 	})
 
-	strings := func(s ...string) []string {
-		return s
-	}
-
 	testCases := []testCase{
 		{
 			name:      "std out echo",
-			input:     strings("-p", "testdata/project", "run", "hello_stdout"),
+			input:     args("-p", "testdata/project", "run", "hello_stdout"),
 			stdoutput: "Hello stdout\n",
 			erroutput: "",
 			err:       nil,
 		},
 		{
 			name:      "std err echo",
-			input:     strings("-p", "testdata/project", "run", "hello_stderr"),
+			input:     args("-p", "testdata/project", "run", "hello_stderr"),
 			stdoutput: "",
 			erroutput: "\x1b[31;1mHello stderr\x1b[0m\n",
 			err:       nil,
 		},
 		{
 			name:      "exit 0",
-			input:     strings("-p", "testdata/project", "run", "exit_0"),
+			input:     args("-p", "testdata/project", "run", "exit_0"),
 			stdoutput: "",
 			erroutput: "",
 			err:       nil,
 		},
 		{
 			name:      "exit 1",
-			input:     strings("-p", "testdata/project", "run", "exit_1"),
+			input:     args("-p", "testdata/project", "run", "exit_1"),
 			stdoutput: "",
 			erroutput: "Error: exit code 4 - Failed executing script `exit_1`: shell script `exit 1`\nExit code: 1\n",
 			err:       errors.New("exit code 4 - Failed executing script `exit_1`: shell script `exit 1`\nExit code: 1"),
 		},
 		{
 			name:      "project with absolute path",
-			input:     strings("-p", filepath.Join(pwd, "testdata/project"), "run", "hello_stdout"),
+			input:     args("-p", filepath.Join(pwd, "testdata/project"), "run", "hello_stdout"),
 			stdoutput: "Hello stdout\n",
 			erroutput: "",
 			err:       nil,
 		},
 		{
 			name:      "project without shuttle.yaml",
-			input:     strings("-p", "testdata/base", "run", "hello_stdout"),
+			input:     args("-p", "testdata/base", "run", "hello_stdout"),
 			stdoutput: "",
 			erroutput: `Error: exit code 2 - Failed to load shuttle configuration: shuttle.yaml file not found
 
@@ -96,7 +92,7 @@ Make sure you are in a project using shuttle and that a 'shuttle.yaml' file is a
 		},
 		{
 			name:      "script fails when required argument is missing",
-			input:     strings("-p", "testdata/project", "run", "required_arg"),
+			input:     args("-p", "testdata/project", "run", "required_arg"),
 			stdoutput: "",
 			erroutput: `Error: exit code 2 - Arguments not valid:
  'foo' not supplied but is required
@@ -112,21 +108,21 @@ Script 'required_arg' accepts the following arguments:
 		},
 		{
 			name:      "script succeeds with required argument",
-			input:     strings("-p", "testdata/project", "run", "required_arg", "foo=bar"),
+			input:     args("-p", "testdata/project", "run", "required_arg", "foo=bar"),
 			stdoutput: "bar\n",
 			erroutput: "",
 			err:       nil,
 		},
 		{
 			name:      "script succeeds with required argument missing and validation disabled",
-			input:     strings("-p", "testdata/project", "run", "--validate=false", "required_arg"),
+			input:     args("-p", "testdata/project", "run", "--validate=false", "required_arg"),
 			stdoutput: "\n",
 			erroutput: "",
 			err:       nil,
 		},
 		{
 			name:      "script fails when validation is disabled and argument is not in valid format",
-			input:     strings("-p", "testdata/project", "run", "--validate=false", "required_arg", "foo"),
+			input:     args("-p", "testdata/project", "run", "--validate=false", "required_arg", "foo"),
 			stdoutput: "",
 			erroutput: `Error: exit code 2 - Arguments not valid:
  'foo' not <argument>=<value>
@@ -142,7 +138,7 @@ Script 'required_arg' accepts the following arguments:
 		},
 		{
 			name:      "script fails on unkown argument",
-			input:     strings("-p", "testdata/project", "run", "required_arg", "foo=bar", "a=b"),
+			input:     args("-p", "testdata/project", "run", "required_arg", "foo=bar", "a=b"),
 			stdoutput: "",
 			erroutput: `Error: exit code 2 - Arguments not valid:
  'a' unknown
@@ -158,7 +154,7 @@ Script 'required_arg' accepts the following arguments:
 		},
 		{
 			name:  "branched git plan",
-			input: strings("-p", "testdata/project-git-branched", "run", "say"),
+			input: args("-p", "testdata/project-git-branched", "run", "say"),
 			stdoutput: `Cloning plan https://github.com/lunarway/shuttle-example-go-plan.git
 something clever
 `,
@@ -167,7 +163,7 @@ something clever
 		},
 		{
 			name:  "git plan",
-			input: strings("-p", "testdata/project-git", "run", "say"),
+			input: args("-p", "testdata/project-git", "run", "say"),
 			stdoutput: `Cloning plan https://github.com/lunarway/shuttle-example-go-plan.git
 something masterly
 `,
@@ -176,14 +172,14 @@ something masterly
 		},
 		{
 			name:      "tagged git plan",
-			input:     strings("-p", "testdata/project-git", "--plan", "#tagged", "run", "say"),
+			input:     args("-p", "testdata/project-git", "--plan", "#tagged", "run", "say"),
 			stdoutput: "\x1b[032;1mOverload git plan branch/tag/sha with tagged\x1b[0m\n\x1b[032;1mSkipping plan pull because its running on detached head\x1b[0m\nsomething tagged\n",
 			erroutput: "",
 			err:       nil,
 		},
 		{
 			name:      "sha git plan",
-			input:     strings("-p", "testdata/project-git", "--plan", "#2b52c21", "run", "say"),
+			input:     args("-p", "testdata/project-git", "--plan", "#2b52c21", "run", "say"),
 			stdoutput: "\x1b[032;1mOverload git plan branch/tag/sha with 2b52c21\x1b[0m\n\x1b[032;1mSkipping plan pull because its running on detached head\x1b[0m\nsomething minor\n",
 			erroutput: "",
 			err:       nil,


### PR DESCRIPTION
An args test helper function was introduced in
99d93c84e139df28235b87315359a87693c4e7f7 (#94) but all tests were not migrated
to use it in that change.

This change updates the test code removing the rest of the strings functions and
use the shared args.