### PR TITLE
Run cleanup in all accept tests

### DIFF
--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -5,6 +5,10 @@ import (
 )
 
 func TestGet(t *testing.T) {
+	t.Cleanup(func() {
+		removeShuttleDirectories(t)
+	})
+
 	testCases := []testCase{
 		{
 			name:      "local plan",

--- a/cmd/has_test.go
+++ b/cmd/has_test.go
@@ -6,6 +6,10 @@ import (
 )
 
 func TestHas(t *testing.T) {
+	t.Cleanup(func() {
+		removeShuttleDirectories(t)
+	})
+
 	testCases := []testCase{
 		{
 			name:      "has variable",

--- a/cmd/ls_test.go
+++ b/cmd/ls_test.go
@@ -5,6 +5,10 @@ import (
 )
 
 func TestLs(t *testing.T) {
+	t.Cleanup(func() {
+		removeShuttleDirectories(t)
+	})
+
 	testCases := []testCase{
 		{
 			name:      "list one action",

--- a/cmd/plan_test.go
+++ b/cmd/plan_test.go
@@ -5,6 +5,10 @@ import (
 )
 
 func TestPlan(t *testing.T) {
+	t.Cleanup(func() {
+		removeShuttleDirectories(t)
+	})
+
 	testCases := []testCase{
 		{
 			name:      "no plan",

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -2,45 +2,20 @@ package cmd
 
 import (
 	"errors"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
-func removeShuttleDirectories(t *testing.T, pwd string) {
-	t.Helper()
-	var directoriesToRemove []string
-	err := fs.WalkDir(os.DirFS(pwd), "testdata", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() && d.Name() == ".shuttle" {
-			directoriesToRemove = append(directoriesToRemove, path)
-		}
-		return nil
-	})
-	if err != nil {
-		t.Errorf("Failed to cleanup .shuttle files: %v", err)
-	}
-
-	for _, d := range directoriesToRemove {
-		err := os.RemoveAll(d)
-		if err != nil {
-			t.Errorf("Failed to cleanup '%s': %v", d, err)
-		}
-	}
-}
-
 func TestRun(t *testing.T) {
+	t.Cleanup(func() {
+		removeShuttleDirectories(t)
+	})
+
 	pwd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("Failed to get working directory: %v", err)
 	}
-
-	t.Cleanup(func() {
-		removeShuttleDirectories(t, pwd)
-	})
 
 	testCases := []testCase{
 		{


### PR DESCRIPTION
To make sure tests clean up after them selves a t.Cleanup() function is
registered removing any .shuttle directories in the acceptance test "testdata"
directory.