### PR TITLE
Migrate has accept tests from shunit2 to Go

### DIFF
--- a/cmd/has.go
+++ b/cmd/has.go
@@ -42,9 +42,9 @@ func newHas(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 
 			if outputAsStdout {
 				if found {
-					fmt.Print("true")
+					fmt.Fprint(cmd.OutOrStdout(), "true")
 				} else {
-					fmt.Print("false")
+					fmt.Fprint(cmd.OutOrStderr(), "false")
 				}
 				return nil
 			} else {

--- a/cmd/has_test.go
+++ b/cmd/has_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 )
@@ -12,18 +13,53 @@ func TestHas(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name:      "has variable",
-			input:     args("-p", "../examples/repo-project", "has", "docker.baseImage"),
+			name:      "bool variable",
+			input:     args("-p", "testdata/project", "has", "boolVar"),
 			stdoutput: "",
 			erroutput: "",
 			err:       nil,
 		},
 		{
 			name:      "has wrong argument switch",
-			input:     args("-j", "../examples/repo-project", "has", "docker.baseImage"),
+			input:     args("-j", "testdata/project", "has", "docker.baseImage"),
 			stdoutput: "",
 			erroutput: "",
 			err:       fmt.Errorf("unknown shorthand flag: 'j' in -j"),
+		},
+		{
+			name:      "stdout",
+			input:     args("-p", "testdata/project", "has", "--stdout", "boolVar"),
+			stdoutput: "true",
+			erroutput: "",
+			err:       nil,
+		},
+		{
+			name:      "not existing",
+			input:     args("-p", "testdata/project", "has", "unknown"),
+			stdoutput: "",
+			erroutput: "",
+			err:       errors.New("exit code 1 - "),
+		},
+		{
+			name:      "not existing stdout",
+			input:     args("-p", "testdata/project", "has", "--stdout", "unknown"),
+			stdoutput: "false",
+			erroutput: "",
+			err:       nil,
+		},
+		{
+			name:      "script",
+			input:     args("-p", "testdata/project", "has", "--script", "hello_stdout"),
+			stdoutput: "",
+			erroutput: "",
+			err:       nil,
+		},
+		{
+			name:      "script",
+			input:     args("-p", "testdata/project", "has", "--script", "unknown"),
+			stdoutput: "",
+			erroutput: "",
+			err:       errors.New("exit code 1 - "),
 		},
 	}
 	executeTestCases(t, testCases)

--- a/tests.sh
+++ b/tests.sh
@@ -26,37 +26,6 @@ function assertContains() {
   fi
 }
 
-
-test_can_check_variable_exists() {
-  ./shuttle -p examples/moon-base has run-as-root 2>&1
-}
-
-test_can_check_variable_exists_with_stdout() {
-  result=$(./shuttle -p examples/moon-base has --stdout run-as-root 2>&1)
-  if [[ "$result" != "true" ]]; then
-    fail "Expected output to be 'true', but it was:\n$result"
-  fi
-}
-
-test_can_check_variable_doesnt_exist() {
-  assertErrorCode 1 -p examples/moon-base has not.a.thing 2>&1
-}
-
-test_can_check_variable_doesnt_exist_with_stdout() {
-  result=$(./shuttle -p examples/moon-base has --stdout oh.no 2>&1)
-  if [[ "$result" != "false" ]]; then
-    fail "Expected output to be 'false', but it was:\n$result"
-  fi
-}
-
-test_can_check_if_script_exists() {
-  ./shuttle -p examples/moon-base has --script build 2>&1
-}
-
-test_can_check_if_script_does_not_exist() {
-  assertErrorCode 1 -p examples/moon-base has --script do_not 2>&1
-}
-
 test_can_execute_shuttle_version_without_error() {
   ./shuttle version &>/dev/null
   ./shuttle version --commit &>/dev/null


### PR DESCRIPTION
This change contains the migration of the has command's acceptance tests from
bash and shunit2 to Go.

It also fixes an inconsistency in the has command where it would not write
output to configured output streams.