### PR TITLE
Migrate version accept tests from shunit2 to Go

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -16,9 +16,9 @@ func newVersion(uii *ui.UI) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			uii.SetContext(ui.LevelSilent)
 			if showCommit {
-				fmt.Println(commit)
+				fmt.Fprintln(cmd.OutOrStdout(), commit)
 			} else {
-				fmt.Println(version)
+				fmt.Fprintln(cmd.OutOrStdout(), version)
 			}
 		},
 	}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	testCases := []testCase{
+		{
+			name:      "no args",
+			input:     args("version"),
+			stdoutput: "<dev-version>\n",
+			erroutput: "",
+			err:       nil,
+		},
+		{
+			name:      "with commit",
+			input:     args("version", "--commit"),
+			stdoutput: "<unspecified-commit>\n",
+			erroutput: "",
+			err:       nil,
+		},
+	}
+	executeTestCases(t, testCases)
+}

--- a/tests.sh
+++ b/tests.sh
@@ -18,19 +18,6 @@ function assertErrorCode() {
   fi
 }
 
-function assertContains() {
-  local expectedResult=$1
-  local actualResult=$2
-  if [[ ! "$actualResult" =~ "$expectedResult" ]]; then
-    fail "Expected output to contain '$expectedResult', but it was:\n$actualResult"
-  fi
-}
-
-test_can_execute_shuttle_version_without_error() {
-  ./shuttle version &>/dev/null
-  ./shuttle version --commit &>/dev/null
-}
-
 test_template_local_path() {
   assertErrorCode 0 -p examples/moon-base template ../custom-template.tmpl -o Dockerfile-custom GO_VERSION=1.16
 }


### PR DESCRIPTION
This change contains the migration of the version command's acceptance tests
from bash and shunit2 to Go. It also fixes an inconsistency in the output
streams where the version command would always write to os.Stdout.