### PR TITLE
Migrate template accept tests from shunit2 to Go

### DIFF
--- a/cmd/template_test.go
+++ b/cmd/template_test.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestTemplate(t *testing.T) {
+	t.Cleanup(func() {
+		removeShuttleDirectories(t)
+	})
+
+	testCases := []testCase{
+		{
+			name:  "local path",
+			input: args("-p", "testdata/project", "template", "../custom-template.tmpl", "GO_VERSION=1.17"),
+			stdoutput: `# Custom docker file template not located inside a project
+FROM golang:1.17-alpine
+`,
+			erroutput: "",
+			err:       nil,
+		},
+		{
+			name:  "alternative delimiters",
+			input: args("-p", "testdata/project", "template", "../custom-template-alternative-delims.tmpl", "--delims", ">>,<<"),
+			stdoutput: `FROM golang:1.17-alpine
+LABEL svc=shuttle
+`,
+			erroutput: "",
+			err:       nil,
+		},
+	}
+	executeTestCases(t, testCases)
+}

--- a/cmd/testdata/custom-template-alternative-delims.tmpl
+++ b/cmd/testdata/custom-template-alternative-delims.tmpl
@@ -1,0 +1,2 @@
+FROM golang:1.17-alpine
+LABEL svc=>> get "service" .Vars <<

--- a/cmd/testdata/custom-template.tmpl
+++ b/cmd/testdata/custom-template.tmpl
@@ -1,0 +1,7 @@
+# Custom docker file template not located inside a project
+{{-
+  $imageTag :=
+    get "GO_VERSION" .Args |
+    printf "%s-alpine"
+}}
+FROM golang:{{ $imageTag }}

--- a/tests.sh
+++ b/tests.sh
@@ -8,25 +8,6 @@ if [[ $buildExitCode -ne 0 ]]; then
   exit $buildExitCode
 fi
 
-function assertErrorCode() {
-  local expectedErrorCode=$1
-  shift
-  result=$(./shuttle "$@" 2>&1)
-  result_status=$?
-  if [[ $result_status -ne $expectedErrorCode ]]; then
-    fail "Status code wasn't $expectedErrorCode but $result_status\nOutput: $result"
-  fi
-}
-
-test_template_local_path() {
-  assertErrorCode 0 -p examples/moon-base template ../custom-template.tmpl -o Dockerfile-custom GO_VERSION=1.16
-}
-
-test_template_local_path_alternate_delims() {
-  result=$(./shuttle -p examples/moon-base template ../custom-template-alternate-delims.tmpl --delims ">>,<<")
-  assertEquals "FROM earth-united/moon-base" "$result"
-}
-
 test_run_sub_dir_say() {
   result=$(cd examples/stepping-stone/sub-dir && ./../../../shuttle run say)
   pwd=$(pwd)


### PR DESCRIPTION
This change contains the migration of the template command's acceptance tests
from bash and shunit2 to Go.