### PR TITLE
Fix shell output race condition

### DIFF
--- a/pkg/executors/shell.go
+++ b/pkg/executors/shell.go
@@ -1,141 +1,84 @@
 package executors
 
 import (
-	"bufio"
 	"context"
-	"errors"
-	"fmt"
-	"io"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"sync"
-	"syscall"
-	"time"
 
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-cmd/cmd"
 	"github.com/lunarway/shuttle/pkg/config"
-	shuttleerrors "github.com/lunarway/shuttle/pkg/errors"
+	"github.com/lunarway/shuttle/pkg/errors"
 )
 
 // Build builds the docker image from a shuttle plan
 func executeShell(ctx context.Context, context ActionExecutionContext) error {
-	execCmd := exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf("cd '%s'; %s", context.ScriptContext.Project.ProjectPath, context.Action.Shell))
-	context.ScriptContext.Project.UI.Verboseln("Starting shell command: %+v", execCmd.String())
+	cmdOptions := cmd.Options{
+		Buffered:  false,
+		Streaming: true,
+		// support large outputs from scripts
+		LineBufferSize: 512e3,
+	}
+
+	cmdArgs := []string{"-c", fmt.Sprintf("cd '%s'; %s", context.ScriptContext.Project.ProjectPath, context.Action.Shell)}
+	execCmd := cmd.NewCmdOptions(cmdOptions, "sh", cmdArgs...)
+	context.ScriptContext.Project.UI.Verboseln("Starting shell command: %s %s", execCmd.Name, strings.Join(cmdArgs, " "))
 
 	setupCommandEnvironmentVariables(execCmd, context)
 
-	stdout, err := execCmd.StdoutPipe()
-	if err != nil {
-		return fmt.Errorf("get stdout pipe: %w", err)
-	}
+	outputReadCompleted := make(chan struct{})
 
-	stderr, err := execCmd.StderrPipe()
-	if err != nil {
-		return fmt.Errorf("get stderr pipe: %w", err)
-	}
-
-	// Set process group ID so the cmd and all its children become a new process
-	// group. This allows Stop to SIGTERM the cmd's process group without killing
-	// this process (i.e. this code here). Note that this does not support
-	// windows. this is copied from go-cmd:
-	// https://github.com/go-cmd/cmd/blob/9e40bcc1acc0e559af2c2e99ae5674ae25cde397/cmd_darwin.go#L15
-	execCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-
-	err = execCmd.Start()
-	if err != nil {
-		return fmt.Errorf("start command: %w", err)
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-	// unusual use of sync.WaitGroup here. The os/exec.Cmd#Wait method will wait
-	// for the stdout and stderr streams to be read but to be sure that the
-	// execution does not move on before our scanner Go routines have returned we
-	// add this wait.
-	defer wg.Wait()
-
-	go stdScanner(&wg, stderr, context.ScriptContext.Project.UI.Errorln)
-	go stdScanner(&wg, stdout, context.ScriptContext.Project.UI.Infoln)
-
-	err = waitOrStop(ctx, execCmd, 5*time.Second)
-	if err != nil {
-		var exitError *exec.ExitError
-		if errors.As(err, &exitError) {
-			exitCode := exitError.ExitCode()
-			if exitCode > 0 {
-				return shuttleerrors.NewExitCode(4, "Failed executing script `%s`: shell script `%s`\nExit code: %v", context.ScriptContext.ScriptName, context.Action.Shell, exitCode)
-			}
-		}
-		return err
-	}
-
-	return nil
-}
-
-// waitOrStop waits for the already-started command cmd by calling its Wait
-// method.
-//
-// If cmd does not return before ctx is done, waitOrStop sends it the given
-// interrupt signal. If killDelay is positive, waitOrStop waits that additional
-// period for Wait to return before sending os.Kill.
-//
-// This function is inspired by
-// https://github.com/golang/go/blob/cacac8bdc5c93e7bc71df71981fdf32dded017bf/src/cmd/go/script_test.go#L1091
-// and adapted to a non-test context along with handling group termination.
-func waitOrStop(ctx context.Context, cmd *exec.Cmd, killDelay time.Duration) error {
-	interruptChan := make(chan error)
 	go func() {
-		select {
-		case interruptChan <- nil:
-			return
-		case <-ctx.Done():
-		}
+		defer close(outputReadCompleted)
 
-		// Signal the process group (-pid), not just the process, so that the
-		// process and all its children are signaled. Else, child procs can keep
-		// running and keep the stdout/stderr fd open and cause cmd.Wait to hang.
-		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
-		if err == nil {
-			err = ctx.Err() // Report ctx.Err() as the reason we interrupted.
-		} else if err.Error() == "os: process already finished" {
-			interruptChan <- nil
-			return
-		}
-
-		if killDelay > 0 {
-			timer := time.NewTimer(killDelay)
+		for execCmd.Stdout != nil || execCmd.Stderr != nil {
 			select {
-			// Report ctx.Err() as the reason we interrupted the process...
-			case interruptChan <- ctx.Err():
-				timer.Stop()
-				return
-			// ...but after killDelay has elapsed, fall back to a stronger signal.
-			case <-timer.C:
+			case line, open := <-execCmd.Stdout:
+				if !open {
+					execCmd.Stdout = nil
+					continue
+				}
+				context.ScriptContext.Project.UI.Infoln("%s", line)
+			case line, open := <-execCmd.Stderr:
+				if !open {
+					execCmd.Stderr = nil
+					continue
+				}
+				context.ScriptContext.Project.UI.Errorln("%s", line)
 			}
-
-			// Wait still hasn't returned.
-			// Kill the process harder to make sure that it exits.
-			//
-			// Ignore any error: if cmd.Process has already terminated, we still
-			// want to send ctx.Err() (or the error from the Interrupt call)
-			// to properly attribute the signal that may have terminated it.
-			_ = cmd.Process.Kill()
 		}
-
-		interruptChan <- err
 	}()
 
-	waitErr := cmd.Wait()
+	// Run and wait for Cmd to return, discard Status
+	context.ScriptContext.Project.UI.Titleln("shell: %s", context.Action.Shell)
 
-	interruptErr := <-interruptChan
-	if interruptErr != nil {
-		return interruptErr
+	// stop cmd if context is cancelled
+	go func() {
+		select {
+		case <-ctx.Done():
+			err := execCmd.Stop()
+			if err != nil {
+				context.ScriptContext.Project.UI.Errorln("Failed to stop script '%s': %v", context.Action.Shell, err)
+			}
+		case <-outputReadCompleted:
+		}
+	}()
+
+	select {
+	case status := <-execCmd.Start():
+		<-outputReadCompleted
+		if status.Exit > 0 {
+			return errors.NewExitCode(4, "Failed executing script `%s`: shell script `%s`\nExit code: %v", context.ScriptContext.ScriptName, context.Action.Shell, status.Exit)
+		}
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
-
-	return waitErr
 }
 
-func setupCommandEnvironmentVariables(execCmd *exec.Cmd, context ActionExecutionContext) {
+func setupCommandEnvironmentVariables(execCmd *cmd.Cmd, context ActionExecutionContext) {
 	shuttlePath, _ := filepath.Abs(filepath.Dir(os.Args[0]))
 
 	execCmd.Env = os.Environ()
@@ -148,23 +91,6 @@ func setupCommandEnvironmentVariables(execCmd *exec.Cmd, context ActionExecution
 	// TODO: Add project path as a shuttle specific ENV
 	execCmd.Env = append(execCmd.Env, fmt.Sprintf("PATH=%s", shuttlePath+string(os.PathListSeparator)+os.Getenv("PATH")))
 	execCmd.Env = append(execCmd.Env, fmt.Sprintf("SHUTTLE_PLANS_ALREADY_VALIDATED=%s", context.ScriptContext.Project.LocalPlanPath))
-}
-
-func stdScanner(wg *sync.WaitGroup, reader io.ReadCloser, output func(format string, args ...interface{})) {
-	defer wg.Done()
-
-	scanner := bufio.NewScanner(reader)
-
-	// increase max line capacity of the buffer to allow for reading very long
-	// lines. This sets the maximum to 512k characters per line.
-	const maxCapacity = 512 * 1024
-	buf := make([]byte, maxCapacity)
-	scanner.Buffer(buf, maxCapacity)
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		output("%s", line)
-	}
 }
 
 func init() {

--- a/pkg/executors/shell.go
+++ b/pkg/executors/shell.go
@@ -51,9 +51,6 @@ func executeShell(ctx context.Context, context ActionExecutionContext) error {
 		}
 	}()
 
-	// Run and wait for Cmd to return, discard Status
-	context.ScriptContext.Project.UI.Titleln("shell: %s", context.Action.Shell)
-
 	// stop cmd if context is cancelled
 	go func() {
 		select {


### PR DESCRIPTION
This change partially reverts 48c5180f2a33e5766199ea54ca29cd5c587dd7f6 (#70)
which fixed an issue where large outputs from shell scripts would break output
pipes (#90).

The change replaced go-cmd with a native implementation which on the surface
fixed the large output bug but introduced another subtle race condition in the
output of scripts.

The motivation in the original commit for replacing go-cmd was the missing
ability to configure the output buffers size. That feature is now available in
go-cmd why this change set reverts to use the proven go-cmd implementation. This
removes a lot of complexity from shuttle while also fixing the race condition
identified in #90.