### PR TITLE
Change ownership to Aura

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @lunarway/squad-nasa
+* @lunarway/squad-aura

--- a/shuttle.yaml
+++ b/shuttle.yaml
@@ -1,4 +1,9 @@
 plan: false
+vars:
+  service: shuttle
+  domain: developer-productivity
+  squad: aura
+
 scripts:
   build:
     description: build code


### PR DESCRIPTION
This change adds metadata to the shuttle.yaml file for internal indexing in
Lunar along with setting the owners to aura.