### PR TITLE
Remove global state from executors package

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -16,6 +16,8 @@ func newRun(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 		validateArgs bool
 	)
 
+	executorRegistry := executors.NewExecutorRegistry(executors.ShellExecutor)
+
 	runCmd := &cobra.Command{
 		Use:          "run [command]",
 		Short:        "Run a plan script",
@@ -32,7 +34,7 @@ func newRun(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 			ctx, cancel := withSignal(stdcontext.Background(), uii)
 			defer cancel()
 
-			err = executors.Execute(ctx, context, commandName, args[1:], validateArgs)
+			err = executorRegistry.Execute(ctx, context, commandName, args[1:], validateArgs)
 			if err != nil {
 				return err
 			}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -16,7 +16,7 @@ func newRun(uii *ui.UI, contextProvider contextProvider) *cobra.Command {
 		validateArgs bool
 	)
 
-	executorRegistry := executors.NewExecutorRegistry(executors.ShellExecutor)
+	executorRegistry := executors.NewRegistry(executors.ShellExecutor)
 
 	runCmd := &cobra.Command{
 		Use:          "run [command]",

--- a/pkg/executors/docker.go
+++ b/pkg/executors/docker.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-
-	"github.com/lunarway/shuttle/pkg/config"
 )
 
 // Build builds the docker image from a shuttle plan
@@ -39,12 +37,6 @@ func executeDocker(ctx context.Context, context ActionExecutionContext) error {
 		log.Fatalf("failed to capture stdout or stderr\n")
 	}
 	return nil
-}
-
-func init() {
-	addExecutor(func(action config.ShuttleAction) bool {
-		return action.Dockerfile != ""
-	}, executeDocker)
 }
 
 func copyAndCapture(w io.Writer, r io.Reader) ([]byte, error) {

--- a/pkg/executors/executor.go
+++ b/pkg/executors/executor.go
@@ -17,7 +17,7 @@ type Registry struct {
 type Matcher func(config.ShuttleAction) (Executor, bool)
 type Executor func(context.Context, ActionExecutionContext) error
 
-func NewExecutorRegistry(executors ...Matcher) *Registry {
+func NewRegistry(executors ...Matcher) *Registry {
 	return &Registry{
 		executors: executors,
 	}

--- a/pkg/executors/executor_test.go
+++ b/pkg/executors/executor_test.go
@@ -164,7 +164,7 @@ func TestExecute(t *testing.T) {
 			verboseUI := ui.Create(&bytes.Buffer{}, &bytes.Buffer{})
 			verboseUI.SetUserLevel(ui.LevelVerbose)
 
-			registry := NewExecutorRegistry(ShellExecutor)
+			registry := NewRegistry(ShellExecutor)
 
 			err := registry.Execute(context.Background(), config.ShuttleProjectContext{
 				ProjectPath: ".",
@@ -218,7 +218,7 @@ func TestExecute_contextCancellation(t *testing.T) {
 		cancel()
 	}()
 
-	registry := NewExecutorRegistry(ShellExecutor)
+	registry := NewRegistry(ShellExecutor)
 
 	err := registry.Execute(ctx, projectContext, "serve", nil, true)
 	assert.EqualError(t, err, context.Canceled.Error())

--- a/pkg/executors/executor_test.go
+++ b/pkg/executors/executor_test.go
@@ -164,7 +164,9 @@ func TestExecute(t *testing.T) {
 			verboseUI := ui.Create(&bytes.Buffer{}, &bytes.Buffer{})
 			verboseUI.SetUserLevel(ui.LevelVerbose)
 
-			err := Execute(context.Background(), config.ShuttleProjectContext{
+			registry := NewExecutorRegistry(ShellExecutor)
+
+			err := registry.Execute(context.Background(), config.ShuttleProjectContext{
 				ProjectPath: ".",
 				UI:          verboseUI,
 				Scripts: map[string]config.ShuttlePlanScript{
@@ -216,7 +218,9 @@ func TestExecute_contextCancellation(t *testing.T) {
 		cancel()
 	}()
 
-	err := Execute(ctx, projectContext, "serve", nil, true)
+	registry := NewExecutorRegistry(ShellExecutor)
+
+	err := registry.Execute(ctx, projectContext, "serve", nil, true)
 	assert.EqualError(t, err, context.Canceled.Error())
 
 	// sadly we need to give the docker some time before "docker ps" shows the

--- a/pkg/executors/shell.go
+++ b/pkg/executors/shell.go
@@ -13,6 +13,10 @@ import (
 	"github.com/lunarway/shuttle/pkg/errors"
 )
 
+func ShellExecutor(action config.ShuttleAction) (Executor, bool) {
+	return executeShell, action.Shell != ""
+}
+
 // Build builds the docker image from a shuttle plan
 func executeShell(ctx context.Context, context ActionExecutionContext) error {
 	cmdOptions := cmd.Options{
@@ -88,10 +92,4 @@ func setupCommandEnvironmentVariables(execCmd *cmd.Cmd, context ActionExecutionC
 	// TODO: Add project path as a shuttle specific ENV
 	execCmd.Env = append(execCmd.Env, fmt.Sprintf("PATH=%s", shuttlePath+string(os.PathListSeparator)+os.Getenv("PATH")))
 	execCmd.Env = append(execCmd.Env, fmt.Sprintf("SHUTTLE_PLANS_ALREADY_VALIDATED=%s", context.ScriptContext.Project.LocalPlanPath))
-}
-
-func init() {
-	addExecutor(func(action config.ShuttleAction) bool {
-		return action.Shell != ""
-	}, executeShell)
 }


### PR DESCRIPTION
Currently package executors contains a global slice of actionExector structs
that each executor registeres to with init functions. This makes them hard to
test and tightly coupled along with making it hard to understand the code.

This change introduces a Registry struct that is newed up in the run command
along with selecting what executors should be used. The init functions are
replaced with exported matchers.

A small finding. The docker executor is actually not working but is still
available. This one is not registered in the new registry as the in-complete
implementation will be removed in another change.