### PR TITLE
Remove release workflow conditional

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,6 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    # only allow tags on the master branch
-    if: github.event.release.target_commitish == 'master'
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Currently the release workflow doesn't run as something has changed in the
conditional leading to the workflow being skipped.

This change removes the conditional allowing us to release new versions again.