### PR TITLE
Remove internal squad name from tests

### DIFF
--- a/pkg/config/shuttleconfig_test.go
+++ b/pkg/config/shuttleconfig_test.go
@@ -44,7 +44,7 @@ func TestShuttleConfig_getConf(t *testing.T) {
 				Plan:    ".",
 				PlanRaw: ".",
 				Variables: map[string]interface{}{
-					"squad": "nasa",
+					"squad": "name",
 				},
 				Scripts: map[string]ShuttlePlanScript{
 					"shout": {
@@ -67,7 +67,7 @@ func TestShuttleConfig_getConf(t *testing.T) {
 				Plan:    ".",
 				PlanRaw: ".",
 				Variables: map[string]interface{}{
-					"squad": "nasa",
+					"squad": "name",
 				},
 				Scripts: map[string]ShuttlePlanScript{
 					"shout": {

--- a/pkg/config/testdata/valid/shuttle.yaml
+++ b/pkg/config/testdata/valid/shuttle.yaml
@@ -1,8 +1,8 @@
 plan: .
 vars:
-  squad: nasa
+  squad: name
 scripts:
   shout:
     description: Shout hello
     actions:
-    - shell: echo "HELLO WORLD"
+      - shell: echo "HELLO WORLD"


### PR DESCRIPTION
To clean things up a bit this change removes the use of an internal squad name
at Lunar.