### PR TITLE
Add shuttle config command for debugging

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -141,6 +141,7 @@ func initializedRoot(out, err io.Writer) (*cobra.Command, *ui.UI) {
 		newRun(uii, ctxProvider),
 		newTemplate(uii, ctxProvider),
 		newVersion(uii),
+		newConfig(uii, ctxProvider),
 	)
 
 	return rootCmd, uii

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/lunarway/shuttle/pkg/git"
+	"github.com/lunarway/shuttle/pkg/ui"
+	"github.com/spf13/cobra"
+)
+
+func newConfig(uii *ui.UI, contextProvder contextProvider) *cobra.Command {
+	var envVarsToExclude []string
+
+	envCmd := &cobra.Command{
+		Use:   "config",
+		Short: "Display shuttle context information",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			uii.SetContext(ui.LevelSilent)
+			environmentVariables := os.Environ()
+			shouldExclude := make(map[string]bool)
+
+			for _, envVarToExclude := range envVarsToExclude {
+				shouldExclude[envVarToExclude] = true
+			}
+
+			context, err := contextProvder()
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Version %v\n", version)
+			breakLine(cmd)
+
+			parsedPlan := git.ParsePlan(context.Config.Plan)
+			if parsedPlan.IsGitPlan {
+				fmt.Fprintf(cmd.OutOrStdout(), "Plan: \n%v %v", context.Config.Plan, parsedPlan.Head)
+			} else {
+				fmt.Fprintf(cmd.OutOrStdout(), "Plan: \n%v", context.Config.Plan)
+			}
+			breakLine(cmd)
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Environment: \n")
+			for _, envVar := range environmentVariables {
+				if shouldExclude[extractEnvirontmentVariableName(envVar)] {
+					continue
+				}
+
+				fmt.Fprintf(cmd.OutOrStdout(), "%v\n", envVar)
+			}
+
+			return nil
+		},
+	}
+
+	envCmd.Flags().StringSliceVar(&envVarsToExclude, "exclude-env-vars", make([]string, 0), "Exclude environment variables from being displayed. Example: shuttle config --exclude-env-vars VAR1,VAR2,VAR3")
+	return envCmd
+}
+
+func breakLine(cmd *cobra.Command) {
+	fmt.Fprintln(cmd.OutOrStdout(), "")
+}
+
+func extractEnvirontmentVariableName(s string) string {
+	return strings.Split(s, "=")[0]
+}

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestConfig(t *testing.T) {
+	environmentStateBeforeTest := os.Environ()
+	defer restoreEnvironment(environmentStateBeforeTest)
+
+	os.Clearenv()
+	os.Setenv("VAR1", "TEST1")
+	os.Setenv("VAR2", "TEST2")
+	os.Setenv("VAR3", "TEST3")
+	testCases := []testCase{
+		{
+			name:      "No exlcude should display VAR1, VAR2 and VAR3 for Environment",
+			input:     args("config"),
+			stdoutput: "Version <dev-version>\n\nPlan: \n\nEnvironment: \nVAR1=TEST1\nVAR2=TEST2\nVAR3=TEST3\n",
+			erroutput: "",
+			err:       nil,
+		},
+		{
+			name:      "with exlcude VAR2 and VAR3 should only display VAR1 for Environment",
+			input:     args("config", "--exclude-env-vars", "VAR2,VAR3"),
+			stdoutput: "Version <dev-version>\n\nPlan: \n\nEnvironment: \nVAR1=TEST1\n",
+			erroutput: "",
+			err:       nil,
+		},
+	}
+
+	executeTestCases(t, testCases)
+}
+
+func restoreEnvironment(originalState []string) {
+	for _, envVar := range originalState {
+		splitted := strings.Split(envVar, "=")
+		key := splitted[0]
+		val := splitted[1]
+
+		os.Setenv(key, val)
+	}
+}


### PR DESCRIPTION
Adds a new  command: config
Simply outputs the shuttle verison, all environment variables and current plan

Usage example: 
```
$ shuttle config
Version 0.15.1

Environment:
PATH=/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOSTNAME=7c047f3af68d
GOLANG_VERSION=1.19.3
GOPATH=/go
TEST_VAR1=TEST1
TEST_VAR2=TEST2
HOME=/root

Plan:
https://github.com/lunarway/shuttle-example-go-plan.git master
```

Allows for excluding specific environment variables from being displayed in case they contain sensitive information. 

```
$ shuttle config --exclude-env-vars HOSTNAME,TEST_VAR2
Version 0.15.1

Environment:
PATH=/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
GOLANG_VERSION=1.19.3
GOPATH=/go
TEST_VAR1=TEST1
HOME=/root

Plan:
https://github.com/lunarway/shuttle-example-go-plan.git master
```