### PR TITLE
Fix some minor formatting on config command

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -37,7 +37,6 @@ func newConfig(uii *ui.UI, contextProvder contextProvider) *cobra.Command {
 			if parsedPlan.IsGitPlan {
 				fmt.Fprintf(cmd.OutOrStdout(), "Plan:\n%v %v", context.Config.Plan, parsedPlan.Head)
 			} else {
-				fmt.Printf("%+v\n", context.Config)
 				plan := context.Config.Plan
 				if plan == "" {
 					plan = "false"

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -35,13 +35,19 @@ func newConfig(uii *ui.UI, contextProvder contextProvider) *cobra.Command {
 
 			parsedPlan := git.ParsePlan(context.Config.Plan)
 			if parsedPlan.IsGitPlan {
-				fmt.Fprintf(cmd.OutOrStdout(), "Plan: \n%v %v", context.Config.Plan, parsedPlan.Head)
+				fmt.Fprintf(cmd.OutOrStdout(), "Plan:\n%v %v", context.Config.Plan, parsedPlan.Head)
 			} else {
-				fmt.Fprintf(cmd.OutOrStdout(), "Plan: \n%v", context.Config.Plan)
+				fmt.Printf("%+v\n", context.Config)
+				plan := context.Config.Plan
+				if plan == "" {
+					plan = "false"
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "Plan:\n%v", plan)
 			}
 			breakLine(cmd)
+			breakLine(cmd)
 
-			fmt.Fprintf(cmd.OutOrStdout(), "Environment: \n")
+			fmt.Fprintf(cmd.OutOrStdout(), "Environment:\n")
 			for _, envVar := range environmentVariables {
 				if shouldExclude[extractEnvirontmentVariableName(envVar)] {
 					continue

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -2,44 +2,53 @@ package cmd
 
 import (
 	"os"
-	"strings"
+	"regexp"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConfig(t *testing.T) {
-	environmentStateBeforeTest := os.Environ()
-	defer restoreEnvironment(environmentStateBeforeTest)
-
-	os.Clearenv()
-	os.Setenv("VAR1", "TEST1")
-	os.Setenv("VAR2", "TEST2")
-	os.Setenv("VAR3", "TEST3")
+	variables := map[string]string{
+		"VAR1": "TEST1",
+		"VAR2": "TEST2",
+		"VAR3": "TEST3",
+	}
+	t.Cleanup(func() {
+		for n := range variables {
+			os.Unsetenv(n)
+		}
+	})
+	for n, v := range variables {
+		os.Setenv(n, v)
+	}
 	testCases := []testCase{
 		{
 			name:      "No exlcude should display VAR1, VAR2 and VAR3 for Environment",
 			input:     args("config"),
-			stdoutput: "Version <dev-version>\n\nPlan: \n\nEnvironment: \nVAR1=TEST1\nVAR2=TEST2\nVAR3=TEST3\n",
+			stdoutput: "(?s)^Version <dev-version>\n\nPlan:\nfalse\n\nEnvironment:\n.*VAR1=TEST1\nVAR2=TEST2\nVAR3=TEST3\n$",
 			erroutput: "",
 			err:       nil,
 		},
 		{
 			name:      "with exlcude VAR2 and VAR3 should only display VAR1 for Environment",
 			input:     args("config", "--exclude-env-vars", "VAR2,VAR3"),
-			stdoutput: "Version <dev-version>\n\nPlan: \n\nEnvironment: \nVAR1=TEST1\n",
+			stdoutput: "(?s)^Version <dev-version>\n\nPlan:\nfalse\n\nEnvironment:\n.*VAR1=TEST1\n$",
+			erroutput: "",
+			err:       nil,
+		},
+		{
+			name:      "git plan",
+			input:     args("-p", "testdata/project-git", "config"),
+			stdoutput: "(?s)^Version <dev-version>\n\nPlan:\nhttps://github.com/lunarway/shuttle-example-go-plan.git master\n\nEnvironment:\n.*VAR1=TEST1\nVAR2=TEST2\nVAR3=TEST3\n",
 			erroutput: "",
 			err:       nil,
 		},
 	}
 
-	executeTestCases(t, testCases)
-}
-
-func restoreEnvironment(originalState []string) {
-	for _, envVar := range originalState {
-		splitted := strings.Split(envVar, "=")
-		key := splitted[0]
-		val := splitted[1]
-
-		os.Setenv(key, val)
-	}
+	executeTestCasesWithCustomAssertion(t, testCases, func(t *testing.T, tc testCase, stdout, stderr string) {
+		t.Helper()
+		assert.Regexp(t, regexp.MustCompile(tc.stdoutput), stdout, "std output not as expected")
+		assert.Equal(t, tc.erroutput, stderr, "err output not as expected")
+	})
 }

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -21,7 +21,7 @@ type testCase struct {
 	err       error
 }
 
-func executeTestCases(t *testing.T, testCases []testCase) {
+func executeTestCasesWithCustomAssertion(t *testing.T, testCases []testCase, assertion func(t *testing.T, tc testCase, stdout, stderr string)) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// remove any .shuttle files up front and after each test to make sure the
@@ -45,10 +45,16 @@ func executeTestCases(t *testing.T, testCases []testCase) {
 			}
 			t.Logf("STDOUT: %s", stdBuf.String())
 			t.Logf("STDERR: %s", errBuf.String())
-			assert.Equal(t, tc.stdoutput, stdBuf.String(), "std output not as expected")
-			assert.Equal(t, tc.erroutput, errBuf.String(), "err output not as expected")
+			assertion(t, tc, stdBuf.String(), errBuf.String())
 		})
 	}
+}
+
+func executeTestCases(t *testing.T, testCases []testCase) {
+	executeTestCasesWithCustomAssertion(t, testCases, func(t *testing.T, tc testCase, stdout, stderr string) {
+		assert.Equal(t, tc.stdoutput, stdout, "std output not as expected")
+		assert.Equal(t, tc.erroutput, stderr, "err output not as expected")
+	})
 }
 
 func removeShuttleDirectories(t *testing.T) {

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -224,8 +224,12 @@ func gitCmd(command string, dir string, uii *ui.UI) error {
 	status := <-execCmd.Start()
 	<-doneChan
 
-	if status.Exit > 0 {
-		return errors.NewExitCode(4, "Failed executing git command `%s` in `%s`. Got exit code: %v\n%s", command, dir, status.Exit, strings.Join(status.Stderr, "\n"))
+	if status.Exit != 0 {
+		errorMessage := fmt.Sprintf("Failed executing git command `%s` in `%s`. Got exit code: %v\n", command, dir, status.Exit)
+		if status.Error != nil {
+			errorMessage += fmt.Sprintf("Message: %v\n", status.Error.Error())
+		}
+		return errors.NewExitCode(4, errorMessage)
 	}
 	return nil
 }


### PR DESCRIPTION
There are some odd whitespaces in the config command output and missing line
breaks if no plan is used.

This change expands the test cases to cover these scenarios which located a big
in the gitCmd function in package git where an os/exec error would go unnoticed.

This change fixes that bug along with the formatting. A change to how the tests
are run was needed to make assertions environment agnostic as we cannot clear
the environment variabls up front as that breakes stuff like PATH used for plans
with git.