### PR TITLE
Copy local plan to .shuttle directory

### DIFF
--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -148,6 +148,13 @@ something masterly
 			erroutput: "",
 			err:       nil,
 		},
+		{
+			name:      "Local project",
+			input:     args("--project", "./testdata/project-local/service", "--plan", "./testdata/project-local/plan", "run", "hello-plan"),
+			stdoutput: "Using overloaded plan ./testdata/project-local/plan\nHello from plan\n",
+			erroutput: "",
+			err:       nil,
+		},
 		// FIXME: This case actually hits a bug as we do not support fetching specific commits
 		// {
 		// 	name:      "sha git plan",
@@ -158,4 +165,15 @@ something masterly
 		// },
 	}
 	executeTestCases(t, testCases)
+
+	testContainsCases := []testCase{
+		{
+			name:      "Local project fail",
+			input:     args("--project", "./testdata/project-local/service", "--plan", "./testdata/wrong-project-local/plan", "run", "hello-plan"),
+			stdoutput: "",
+			erroutput: "shuttle/cmd/testdata/wrong-project-local/plan: no such file or directory",
+			err:       errors.New("shuttle/cmd/testdata/wrong-project-local/plan: no such file or directory"),
+		},
+	}
+	executeTestContainsCases(t, testContainsCases)
 }

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -57,6 +57,31 @@ func executeTestCases(t *testing.T, testCases []testCase) {
 	})
 }
 
+func executeTestContainsCases(t *testing.T, testCases []testCase) {
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// remove any .shuttle files up front and after each test to make sure the
+			// runs are deterministic
+			t.Cleanup(func() {
+				removeShuttleDirectories(t)
+			})
+			removeShuttleDirectories(t)
+
+			stdBuf := new(bytes.Buffer)
+			errBuf := new(bytes.Buffer)
+			rootCmd, _ := initializedRoot(stdBuf, errBuf)
+			rootCmd.SetArgs(tc.input)
+
+			err := rootCmd.Execute()
+			if tc.err == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tc.err.Error())
+			}
+		})
+	}
+}
+
 func removeShuttleDirectories(t *testing.T) {
 	t.Helper()
 

--- a/cmd/testdata/project-local/plan/plan.yaml
+++ b/cmd/testdata/project-local/plan/plan.yaml
@@ -1,0 +1,7 @@
+vars:
+  language: go
+scripts:
+  hello-plan:
+    description: Write output
+    actions:
+      - shell: echo "Hello from plan"

--- a/cmd/testdata/project-local/service/shuttle.yaml
+++ b/cmd/testdata/project-local/service/shuttle.yaml
@@ -1,0 +1,6 @@
+plan: false
+scripts:
+  hello-shuttle:
+    description: Write output
+    actions:
+      - shell: echo "Hello from shuttle"

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
+require golang.org/x/exp v0.0.0-20221114191408-850992195362
+
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,10 +11,9 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
+	golang.org/x/exp v0.0.0-20221114191408-850992195362
 	gopkg.in/yaml.v2 v2.4.0
 )
-
-require golang.org/x/exp v0.0.0-20221114191408-850992195362
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20200414173820-0848c9571904/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 h1:HWj/xjIHfjYU5nVXpTM0s39J9CbLn7Cc5a7IC5rwsMQ=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/exp v0.0.0-20221114191408-850992195362 h1:NoHlPRbyl1VFI6FjwHtPQCN7wAMXI6cKcqrmXhOOfBQ=
+golang.org/x/exp v0.0.0-20221114191408-850992195362/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/copy/copy.go
+++ b/pkg/copy/copy.go
@@ -1,0 +1,86 @@
+package copy
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"golang.org/x/exp/slices"
+)
+
+// File copies a single file from src to dst
+func File(src, dst string) error {
+	var err error
+	var srcfd *os.File
+	var dstfd *os.File
+	var srcinfo os.FileInfo
+
+	srcfd, err = os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcfd.Close()
+
+	dstfd, err = os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer dstfd.Close()
+
+	_, err = io.Copy(dstfd, srcfd)
+	if err != nil {
+		return err
+	}
+
+	srcinfo, err = os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	return os.Chmod(dst, srcinfo.Mode())
+}
+
+// Dir copies a whole directory recursively
+func Dir(src string, dst string, ignorelist []string) error {
+	var err error
+	var fds []os.FileInfo
+	var srcinfo os.FileInfo
+
+	srcinfo, err = os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(dst, srcinfo.Mode())
+	if err != nil {
+		return err
+	}
+
+	fds, err = ioutil.ReadDir(src)
+	if err != nil {
+		return err
+	}
+
+	for _, fd := range fds {
+		srcfp := path.Join(src, fd.Name())
+		dstfp := path.Join(dst, fd.Name())
+
+		shouldIgnore := slices.Contains(ignorelist, fd.Name())
+		if shouldIgnore {
+			continue
+		}
+
+		if fd.IsDir() {
+			if err = Dir(srcfp, dstfp, ignorelist); err != nil {
+				fmt.Println(err)
+			}
+		} else {
+			if err = File(srcfp, dstfp); err != nil {
+				fmt.Println(err)
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
When using shuttle with a local plan the plan is not copied from the source directory to the `.shuttle/plan` directory. This can in some situations be problematic. For instance if a shuttle command is calling a bash script that is located in a parent directory to the shuttle context. 
This is an issue when running for instance Docker commands using shuttle. If the plan is located in a parent directory, Docker will not allow including files that is stored outside of the Docker build context.
Therefore Shuttle should the plan directory into the `.shuttle/plan` directory that is being generated within the context of shuttle. This is illustrated in the following sample:
  
```
This plan ----------------> ├── plan
                            │   └── scripts
                            │   │   └── docker-build.sh
                            │   └── plan.yaml
                            │   └── shuttle.yaml
                            ├── service
                            ├── .shuttle
Should be copied to here -> │   └── plan
                            ├── cmd
                            ├── internal
                            ├── main.go
                            └── shuttle.yaml
```
This PR will implement the approach that is described above. 
