### PR TITLE
feature/add git cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,16 @@ It can also be used to point to a tag or a git SHA, like this:
 - `https://github.com/lunarway/shuttle-example-go-plan.git#v1.2.3`
 - `git://git@github.com:lunarway/shuttle-example-go-plan.git#46ce3cc`
 
+#### Caching
+
+By default shuttle will pull the upstream plan on every pull. To prevent this you can use 
+
+```bash
+export SHUTTLE_CACHE_DURATION_MIN=60 # Cache a plan for 60 minutes
+```
+
+This feature caches pr. repo, as such the cache isn't shared between working repositories. 
+
 ### Overloading the plan
 
 It is possible to overload the plan specified in `shuttle.yaml` file by using the `--plan` argument

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"strconv"
 	"strings"
+	"time"
 
 	go_cmd "github.com/go-cmd/cmd"
 	"github.com/lunarway/shuttle/pkg/errors"
@@ -21,7 +23,9 @@ type Plan struct {
 	Head       string
 }
 
-var gitRegex = regexp.MustCompile(`^((git://((?P<user>[^@]+)@)?(?P<repository1>(?P<host>[^:]+):(?P<path>[^#]*)))|((?P<protocol>https)://(?P<repository2>.*\.git)))(#(?P<head>.*))?$`)
+var gitRegex = regexp.MustCompile(
+	`^((git://((?P<user>[^@]+)@)?(?P<repository1>(?P<host>[^:]+):(?P<path>[^#]*)))|((?P<protocol>https)://(?P<repository2>.*\.git)))(#(?P<head>.*))?$`,
+)
 
 func ParsePlan(plan string) Plan {
 	if !gitRegex.MatchString(plan) {
@@ -68,7 +72,13 @@ func IsPlan(plan string) bool {
 }
 
 // GetGitPlan will pull git repository and return its path
-func GetGitPlan(plan string, localShuttleDirectoryPath string, uii *ui.UI, skipGitPlanPulling bool, planArgument string) (string, error) {
+func GetGitPlan(
+	plan string,
+	localShuttleDirectoryPath string,
+	uii *ui.UI,
+	skipGitPlanPulling bool,
+	planArgument string,
+) (string, error) {
 	parsedGitPlan := ParsePlan(plan)
 
 	if strings.HasPrefix(planArgument, "#") {
@@ -78,7 +88,10 @@ func GetGitPlan(plan string, localShuttleDirectoryPath string, uii *ui.UI, skipG
 
 	planPath := path.Join(localShuttleDirectoryPath, "plan")
 
-	plansAlreadyValidated := strings.Split(os.Getenv("SHUTTLE_PLANS_ALREADY_VALIDATED"), string(os.PathListSeparator))
+	plansAlreadyValidated := strings.Split(
+		os.Getenv("SHUTTLE_PLANS_ALREADY_VALIDATED"),
+		string(os.PathListSeparator),
+	)
 	for _, planAlreadyValidated := range plansAlreadyValidated {
 		if planAlreadyValidated == planPath {
 			uii.Verboseln("Shuttle already validated plan. Skipping further plan validation")
@@ -90,13 +103,20 @@ func GetGitPlan(plan string, localShuttleDirectoryPath string, uii *ui.UI, skipG
 		status := getStatus(planPath)
 
 		if status.mergeState {
-			return "", errors.NewExitCode(9, "Plan's cloned output is in merge state. Please resolve merge conflicts and the try again")
+			return "", errors.NewExitCode(
+				9,
+				"Plan's cloned output is in merge state. Please resolve merge conflicts and the try again",
+			)
 		} else if status.changes {
 			uii.EmphasizeInfoln("Found %v files locally changed in plan", len(status.files))
 			uii.EmphasizeInfoln("Skipping plan pull because of changes")
 		} else {
 			if skipGitPlanPulling {
 				uii.Verboseln("Skipping git plan pulling")
+				return planPath, nil
+			}
+			if valid, ok := cacheIsValid(planPath); ok && valid {
+				uii.Verboseln("Cache is still valid continuing")
 				return planPath, nil
 			}
 			err := gitCmd("fetch origin", planPath, uii)
@@ -146,8 +166,32 @@ func GetGitPlan(plan string, localShuttleDirectoryPath string, uii *ui.UI, skipG
 	return planPath, nil
 }
 
-func RunGitPlanCommand(command string, plan string, uii *ui.UI) {
+func cacheIsValid(planPath string) (valid bool, ok bool) {
+	duration := os.Getenv("SHUTTLE_CACHE_DURATION_MIN")
+	if duration == "" {
+		return false, false
+	}
 
+	durationMin, err := strconv.Atoi(duration)
+	if err != nil {
+		return false, false
+	}
+
+	fi, err := os.Stat(planPath)
+	if err != nil {
+		return false, false
+	}
+
+	folderTime := fi.ModTime()
+	cacheTime := folderTime.Local().Add(time.Minute * time.Duration(durationMin))
+	if folderTime.Before(cacheTime) {
+		return true, true
+	}
+
+	return false, true
+}
+
+func RunGitPlanCommand(command string, plan string, uii *ui.UI) {
 	cmdOptions := go_cmd.Options{
 		Buffered:  false,
 		Streaming: true,
@@ -225,7 +269,12 @@ func gitCmd(command string, dir string, uii *ui.UI) error {
 	<-doneChan
 
 	if status.Exit != 0 {
-		errorMessage := fmt.Sprintf("Failed executing git command `%s` in `%s`. Got exit code: %v\n", command, dir, status.Exit)
+		errorMessage := fmt.Sprintf(
+			"Failed executing git command `%s` in `%s`. Got exit code: %v\n",
+			command,
+			dir,
+			status.Exit,
+		)
 		if status.Error != nil {
 			errorMessage += fmt.Sprintf("Message: %v\n", status.Error.Error())
 		}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -27,6 +27,8 @@ var gitRegex = regexp.MustCompile(
 	`^((git://((?P<user>[^@]+)@)?(?P<repository1>(?P<host>[^:]+):(?P<path>[^#]*)))|((?P<protocol>https)://(?P<repository2>.*\.git)))(#(?P<head>.*))?$`,
 )
 
+const cacheDurationMinKey = "SHUTTLE_CACHE_DURATION_MIN"
+
 func ParsePlan(plan string) Plan {
 	if !gitRegex.MatchString(plan) {
 		return Plan{
@@ -170,15 +172,16 @@ func GetGitPlan(
 	return planPath, nil
 }
 
+// cacheIsValid optionally allows the plan to be cached, depending on when it was modified last. It is opt in only
 func cacheIsValid(planPath string) (bool, error) {
-	duration := os.Getenv("SHUTTLE_CACHE_DURATION_MIN")
+	duration := os.Getenv(cacheDurationMinKey)
 	if duration == "" {
 		return false, nil
 	}
 
 	durationMin, err := strconv.Atoi(duration)
 	if err != nil {
-		return false, fmt.Errorf("SHUTTLE_CACHE_DURATION_MIN is not valid: %s", duration)
+		return false, fmt.Errorf("%s is not valid: %s", cacheDurationMinKey, duration)
 	}
 
 	fi, err := os.Stat(planPath)

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -141,6 +141,8 @@ func GetGitPlan(
 					return "", err
 				}
 				status = getStatus(planPath)
+				currentTime := time.Now()
+				os.Chtimes(planPath, currentTime, currentTime)
 			} else {
 				uii.EmphasizeInfoln("Skipping plan pull because its running on detached head")
 			}
@@ -190,8 +192,9 @@ func cacheIsValid(planPath string) (bool, error) {
 	}
 
 	folderTime := fi.ModTime()
-	cacheTime := folderTime.Local().Add(time.Minute * time.Duration(durationMin))
-	return folderTime.Before(cacheTime), nil
+	cacheTime := time.Now().Add(-time.Minute * time.Duration(durationMin))
+
+	return cacheTime.Before(folderTime), nil
 }
 
 func RunGitPlanCommand(command string, plan string, uii *ui.UI) {


### PR DESCRIPTION
The goal of this pr is to enable caching for normal command which pulls plans from git.
Such that regular shuttle ls and shuttle run runs much quicker on subsequent runs.

This is enable only, such that there are no breaking changes. It however can be opted into using env variable.

```
export SHUTTLE_CACHE_DURATION_MIN="60" # cache time in minutes
```

- add optional cache
- add git cache

Fixes: ACE-75
