### PR TITLE
Dont fail if directory exists

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ runs:
         if [ "$(uname)" == "Darwin" ]; then
             curl -LO https://github.com/lunarway/shuttle/releases/download/$(curl -Lso /dev/null -w %{url_effective} https://github.com/lunarway/shuttle/releases/latest | grep -o '[^/]*$')/shuttle-darwin-amd64
             chmod +x shuttle-darwin-amd64
-            mkdir ~/bin
+            mkdir -p ~/bin
             mv shuttle-darwin-amd64 ~/bin/shuttle
             shuttle --help
         elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then


### PR DESCRIPTION
The GitHub Action would fail if the directory already exists. The `-p` removes the error.