### PR TITLE
Add arm64 support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,7 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64
       - 386
     ldflags:
       - "-s -w -X github.com/lunarway/shuttle/cmd.version={{.Version}} -X github.com/lunarway/shuttle/cmd.commit={{.Commit}}"

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Install Shuttle'
-description: 'Installs Lunar Way Shuttle'
+description: 'Installs Lunar Shuttle'
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Introduce ARM64 support to the GoReleaser, so that M1 Macs in the future can use this version instead.