### PR TITLE
feat: use return types when calling the cmder functions

### DIFF
--- a/pkg/executors/golang/cmder/cmder.go
+++ b/pkg/executors/golang/cmder/cmder.go
@@ -90,10 +90,8 @@ func (rc *RootCmd) Execute() {
 				for _, val := range returnValues {
 					if val.Type().Implements(reflect.TypeOf((*error)(nil)).Elem()) {
 						err, ok := val.Interface().(error)
-						if ok {
+						if ok && err != nil {
 							return err
-						} else {
-							log.Fatalln("returnValue is not an error")
 						}
 					}
 				}

--- a/pkg/executors/golang/cmder/cmder.go
+++ b/pkg/executors/golang/cmder/cmder.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 	"reflect"
 
 	"github.com/spf13/cobra"
@@ -27,6 +28,12 @@ func (rc *RootCmd) AddCmds(cmd ...*Cmd) *RootCmd {
 }
 
 func (rc *RootCmd) Execute() {
+	if err := rc.TryExecute(os.Args[1:]); err != nil {
+		log.Fatalf("%v\n", err)
+	}
+}
+
+func (rc *RootCmd) TryExecute(args []string) error {
 	rootcmd := &cobra.Command{Use: "actions"}
 
 	rootcmd.AddCommand(
@@ -107,9 +114,11 @@ func (rc *RootCmd) Execute() {
 		rootcmd.AddCommand(cobracmd)
 	}
 
+	rootcmd.SetArgs(args)
 	if err := rootcmd.Execute(); err != nil {
-		log.Fatalf("%v", err)
+		return err
 	}
+	return nil
 }
 
 type Arg struct {

--- a/pkg/executors/golang/cmder/cmder_test.go
+++ b/pkg/executors/golang/cmder/cmder_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/lunarway/shuttle/pkg/executors/golang/cmder"
 )
 
-func TestCmderWithExit(t *testing.T) {
+func TestCmderWithError(t *testing.T) {
 	testFunc := cmder.NewCmd("test", func(ctx context.Context) error {
 		return errors.New("some-error")
 	})
@@ -24,7 +24,7 @@ func TestCmderWithExit(t *testing.T) {
 	assert.ErrorContains(t, err, "some-error")
 }
 
-func TestCmderWithNoExit(t *testing.T) {
+func TestCmderWithNoError(t *testing.T) {
 	testFunc := cmder.NewCmd("test", func(ctx context.Context) error {
 		return nil
 	})

--- a/pkg/executors/golang/cmder/cmder_test.go
+++ b/pkg/executors/golang/cmder/cmder_test.go
@@ -1,0 +1,81 @@
+package cmder_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lunarway/shuttle/pkg/executors/golang/cmder"
+)
+
+func TestCmderWithExit(t *testing.T) {
+	testFunc := cmder.NewCmd("test", func(ctx context.Context) error {
+		return errors.New("some-error")
+	})
+
+	args := []string{
+		"test",
+	}
+
+	err := cmder.NewRoot().AddCmds(testFunc).TryExecute(args)
+
+	assert.ErrorContains(t, err, "some-error")
+}
+
+func TestCmderWithNoExit(t *testing.T) {
+	testFunc := cmder.NewCmd("test", func(ctx context.Context) error {
+		return nil
+	})
+
+	args := []string{
+		"test",
+	}
+
+	err := cmder.NewRoot().AddCmds(testFunc).TryExecute(args)
+
+	assert.NoError(t, err)
+}
+
+func TestCmderWithMultipeReturns(t *testing.T) {
+	testFunc := cmder.NewCmd("test", func(ctx context.Context) (string, error) {
+		return "something", nil
+	})
+
+	args := []string{
+		"test",
+	}
+
+	err := cmder.NewRoot().AddCmds(testFunc).TryExecute(args)
+
+	assert.NoError(t, err)
+}
+
+func TestCmderWithMultipeReturnsErroring(t *testing.T) {
+	testFunc := cmder.NewCmd("test", func(ctx context.Context) (string, error) {
+		return "something", errors.New("some-error")
+	})
+
+	args := []string{
+		"test",
+	}
+
+	err := cmder.NewRoot().AddCmds(testFunc).TryExecute(args)
+
+	assert.ErrorContains(t, err, "some-error")
+}
+
+func TestCmderWithMultipeReturnsErroringInAnyPlace(t *testing.T) {
+	testFunc := cmder.NewCmd("test", func(ctx context.Context) (error, string) {
+		return errors.New("some-error"), "something"
+	})
+
+	args := []string{
+		"test",
+	}
+
+	err := cmder.NewRoot().AddCmds(testFunc).TryExecute(args)
+
+	assert.ErrorContains(t, err, "some-error")
+}


### PR DESCRIPTION
This actually allows shuttle to handle the return errors of the actions. It will
only look at error types, so if you return multiple types they will be ignored
and only the error will be handled
