### PR TITLE
feat/with upload command

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -154,6 +154,7 @@ func initializedRoot(out, err io.Writer) (*cobra.Command, *ui.UI) {
 		newTemplate(uii, ctxProvider),
 		newVersion(uii),
 		newConfig(uii, ctxProvider),
+		newTelemetry(uii),
 	)
 
 	return rootCmd, uii

--- a/cmd/telemetry_cmd.go
+++ b/cmd/telemetry_cmd.go
@@ -6,7 +6,18 @@ import (
 	"github.com/lunarway/shuttle/pkg/ui"
 )
 
-func newUpload(uii *ui.UI) *cobra.Command {
+func newTelemetry(uii *ui.UI) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "telemetry",
+		Short: "Shuttle telemetry",
+	}
+
+	cmd.AddCommand(newTelemetryUploadCmd(uii))
+
+	return cmd
+}
+
+func newTelemetryUploadCmd(uii *ui.UI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "upload",
 		Short: "Upload shuttle telemetry",

--- a/cmd/telemetry_cmd.go
+++ b/cmd/telemetry_cmd.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
+	"log"
+	"os"
+
 	"github.com/spf13/cobra"
 
+	"github.com/lunarway/shuttle/pkg/telemetry"
 	"github.com/lunarway/shuttle/pkg/ui"
 )
 
@@ -23,6 +27,17 @@ func newTelemetryUploadCmd(uii *ui.UI) *cobra.Command {
 		Short: "Upload shuttle telemetry",
 		Run: func(cmd *cobra.Command, args []string) {
 			uii.SetContext(ui.LevelSilent)
+
+			url := os.Getenv("SHUTTLE_REMOTE_TRACING_URL")
+			if url == "" {
+				log.Fatalln("SHUTTLE_REMOTE_TRACING_URL is not set")
+			}
+
+			uploader := telemetry.NewTelemetryUploader(url)
+
+			if err := uploader.Upload(cmd.Context()); err != nil {
+				log.Fatalf("failed to upload traces: %s", err)
+			}
 		},
 	}
 

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/lunarway/shuttle/pkg/ui"
+)
+
+func newUpload(uii *ui.UI) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "upload",
+		Short: "Upload shuttle telemetry",
+		Run: func(cmd *cobra.Command, args []string) {
+			uii.SetContext(ui.LevelSilent)
+		},
+	}
+
+	return cmd
+}

--- a/pkg/telemetry/jsonlines.go
+++ b/pkg/telemetry/jsonlines.go
@@ -27,7 +27,7 @@ func (t *JsonLinesTelemetryClient) Trace(
 ) {
 	copyHostMap(t.properties, properties)
 
-	event := &uploadTraceEvent{
+	event := &UploadTraceEvent{
 		App:        appKey,
 		Timestamp:  time.Now().UTC(),
 		Properties: includeContext(ctx, properties),
@@ -47,31 +47,11 @@ func (t *JsonLinesTelemetryClient) Trace(
 
 var _ TelemetryClient = &JsonLinesTelemetryClient{}
 
-type uploadTraceEvent struct {
+type UploadTraceEvent struct {
 	App        string            `json:"app"`
 	Timestamp  time.Time         `json:"timestamp"`
 	Properties map[string]string `json:"properties"`
 }
-
-//func (t *JsonLinesTelemetryClient) upload(ctx context.Context, content []byte) error {
-//	resp, err := t.Client.Post(t.url, "application/json", bytes.NewReader(content))
-//	if err != nil {
-//		return err
-//	}
-//	if resp.StatusCode > 299 {
-//		body, err := ioutil.ReadAll(resp.Body)
-//		if err != nil {
-//			return err
-//		}
-//		return fmt.Errorf(
-//			"failed to push trace event with status code: %d, reason: %s",
-//			resp.StatusCode,
-//			string(body),
-//		)
-//	}
-//
-//	return nil
-//}
 
 // filename
 const fileNameShuttleJsonLines = "shuttle-telemetry"

--- a/pkg/telemetry/setup.go
+++ b/pkg/telemetry/setup.go
@@ -30,22 +30,13 @@ func Setup() {
 		sysinfo := WithGoInfo()
 		sysinfo(properties)
 
-		logLocation := os.Getenv("SHUTTLE_REMOTE_LOG_LOCATION")
-		if logLocation == "default" || logLocation == "" {
-			usr, _ := user.Current()
-			homeDir := usr.HomeDir
-			logLocation = path.Join(
-				homeDir,
-				".local",
-				"share",
-				"shuttle",
-				"telemetry",
-			)
-
+		logLocation := getRemoteLogLocation()
+		if logLocation != "" {
 			if err := os.MkdirAll(logLocation, 0o755); err != nil {
 				log.Fatal(err)
 			}
 		}
+
 		client = &JsonLinesTelemetryClient{
 			labelPrefix: appKey,
 			properties:  properties,
@@ -69,4 +60,21 @@ func Setup() {
 
 		return
 	}
+}
+
+func getRemoteLogLocation() string {
+	logLocation := os.Getenv("SHUTTLE_REMOTE_LOG_LOCATION")
+	if logLocation == "default" || logLocation == "" {
+		usr, _ := user.Current()
+		homeDir := usr.HomeDir
+		logLocation = path.Join(
+			homeDir,
+			".local",
+			"share",
+			"shuttle",
+			"telemetry",
+		)
+	}
+
+	return logLocation
 }

--- a/pkg/telemetry/testdata/get-shuttle-telemetry-file/shuttle-telemetry.jsonl
+++ b/pkg/telemetry/testdata/get-shuttle-telemetry-file/shuttle-telemetry.jsonl
@@ -1,0 +1,2 @@
+{ "app": "some-app", "timestamp": "2006-01-02T15:04:05Z", "properties": {}}
+{ "app": "some-app", "timestamp": "2007-01-02T15:04:05Z", "properties": {"some-key": "some-value", "some-other-key": "some-other-value"}}

--- a/pkg/telemetry/uploader.go
+++ b/pkg/telemetry/uploader.go
@@ -1,0 +1,61 @@
+package telemetry
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type (
+	TelemetryUploader struct {
+		url      string
+		rate     *time.Duration
+		uploadmu sync.Mutex
+
+		upload            UploadFunc
+		getTelemetryFiles GetTelemetryFilesFunc
+	}
+
+	UploadFunc            = func(ctx context.Context) error
+	GetTelemetryFilesFunc = func(ctx context.Context) error
+
+	UploadOptions = func(*TelemetryUploader)
+)
+
+func WithRate(rate time.Duration) UploadOptions {
+	return func(tu *TelemetryUploader) {
+		tu.rate = &rate
+	}
+}
+
+func WithUploadFunction(uploadFunc func(ctx context.Context) error) UploadOptions {
+	return func(tu *TelemetryUploader) {
+		tu.upload = uploadFunc
+	}
+}
+
+func WithGetTelemetryFiles(getTelemetryFilesFunc func(ctx context.Context) error) UploadOptions {
+	return func(tu *TelemetryUploader) {
+		tu.getTelemetryFiles = getTelemetryFilesFunc
+	}
+}
+
+func NewTelemetryUploader(url string, options ...UploadOptions) *TelemetryUploader {
+	uploader := &TelemetryUploader{
+		url:               url,
+		upload:            upload,
+		getTelemetryFiles: getTelemetryFiles,
+	}
+
+	for _, o := range options {
+		o(uploader)
+	}
+
+	return uploader
+}
+
+func (tu *TelemetryUploader) Upload(ctx context.Context) {
+}
+
+func upload(ctx context.Context) error            {}
+func getTelemetryFiles(ctx context.Context) error {}

--- a/pkg/telemetry/uploader.go
+++ b/pkg/telemetry/uploader.go
@@ -19,7 +19,7 @@ type (
 	}
 
 	UploadFunc            = func(ctx context.Context) error
-	GetTelemetryFilesFunc = func(ctx context.Context) error
+	GetTelemetryFilesFunc = func(ctx context.Context, location string) ([]string, error)
 
 	UploadOptions = func(*TelemetryUploader)
 )
@@ -30,13 +30,13 @@ func WithRate(rate time.Duration) UploadOptions {
 	}
 }
 
-func WithUploadFunction(uploadFunc func(ctx context.Context) error) UploadOptions {
+func WithUploadFunction(uploadFunc UploadFunc) UploadOptions {
 	return func(tu *TelemetryUploader) {
 		tu.upload = uploadFunc
 	}
 }
 
-func WithGetTelemetryFiles(getTelemetryFilesFunc func(ctx context.Context) error) UploadOptions {
+func WithGetTelemetryFiles(getTelemetryFilesFunc GetTelemetryFilesFunc) UploadOptions {
 	return func(tu *TelemetryUploader) {
 		tu.getTelemetryFiles = getTelemetryFilesFunc
 	}
@@ -64,12 +64,13 @@ func NewTelemetryUploader(url string, options ...UploadOptions) *TelemetryUpload
 }
 
 func (tu *TelemetryUploader) Upload(ctx context.Context) {
+	tu.getTelemetryFiles(ctx, tu.storageLocation)
 }
 
 func upload(ctx context.Context) error {
 	return nil
 }
 
-func getTelemetryFiles(ctx context.Context) error {
-	return nil
+func getTelemetryFiles(ctx context.Context, location string) ([]string, error) {
+	return nil, nil
 }

--- a/pkg/telemetry/uploader.go
+++ b/pkg/telemetry/uploader.go
@@ -12,6 +12,8 @@ type (
 		rate     *time.Duration
 		uploadmu sync.Mutex
 
+		storageLocation string
+
 		upload            UploadFunc
 		getTelemetryFiles GetTelemetryFilesFunc
 	}
@@ -40,11 +42,18 @@ func WithGetTelemetryFiles(getTelemetryFilesFunc func(ctx context.Context) error
 	}
 }
 
+func WithRemoteLogLocation(location string) UploadOptions {
+	return func(tu *TelemetryUploader) {
+		tu.storageLocation = location
+	}
+}
+
 func NewTelemetryUploader(url string, options ...UploadOptions) *TelemetryUploader {
 	uploader := &TelemetryUploader{
 		url:               url,
 		upload:            upload,
 		getTelemetryFiles: getTelemetryFiles,
+		storageLocation:   getRemoteLogLocation(),
 	}
 
 	for _, o := range options {
@@ -57,5 +66,10 @@ func NewTelemetryUploader(url string, options ...UploadOptions) *TelemetryUpload
 func (tu *TelemetryUploader) Upload(ctx context.Context) {
 }
 
-func upload(ctx context.Context) error            {}
-func getTelemetryFiles(ctx context.Context) error {}
+func upload(ctx context.Context) error {
+	return nil
+}
+
+func getTelemetryFiles(ctx context.Context) error {
+	return nil
+}

--- a/pkg/telemetry/uploader_test.go
+++ b/pkg/telemetry/uploader_test.go
@@ -3,7 +3,9 @@ package telemetry
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,5 +35,54 @@ func TestTelemetryUploader(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Equal(t, []string{"testdata/telemetry-files/shuttle-telemetry.jsonl"}, files)
+	})
+
+	t.Run("get shuttle telemetry file", func(t *testing.T) {
+		t.Parallel()
+		uploader := NewTelemetryUploader("some-url")
+
+		files, _, err := uploader.getTelemetryFile(
+			context.Background(),
+			"testdata/get-shuttle-telemetry-file/shuttle-telemetry.jsonl",
+		)
+
+		events := []UploadTraceEvent{
+			{
+				App:        "some-app",
+				Timestamp:  time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC),
+				Properties: map[string]string{},
+			},
+			{
+				App:       "some-app",
+				Timestamp: time.Date(2007, time.January, 2, 15, 4, 5, 0, time.UTC),
+				Properties: map[string]string{
+					"some-key":       "some-value",
+					"some-other-key": "some-other-value",
+				},
+			},
+		}
+
+		require.NoError(t, err)
+		require.Equal(t, events, files)
+	})
+
+	t.Run("full upload test", func(t *testing.T) {
+		t.Parallel()
+
+		uploader := NewTelemetryUploader(
+			"some-url",
+			WithUploadFunction(func(ctx context.Context, url string, event []UploadTraceEvent) error {
+				assert.Equal(t, "some-url", url)
+				assert.NotEmpty(t, event)
+
+				return nil
+			}),
+			WithGetTelemetryFiles(func(ctx context.Context, location string) ([]string, error) {
+				return getTelemetryFiles(ctx, "testdata/full-upload-test")
+			}),
+			WithCleanUp(false))
+
+		err := uploader.Upload(context.Background())
+		require.NoError(t, err)
 	})
 }

--- a/pkg/telemetry/uploader_test.go
+++ b/pkg/telemetry/uploader_test.go
@@ -1,0 +1,37 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTelemetryUploader(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no telemetry files", func(t *testing.T) {
+		t.Parallel()
+
+		uploader := NewTelemetryUploader("some-url")
+
+		files, err := uploader.getTelemetryFiles(
+			context.Background(),
+			"testdata/no-telemetry-files",
+		)
+		require.NoError(t, err)
+		require.Empty(t, files)
+	})
+
+	t.Run("telemetry files", func(t *testing.T) {
+		t.Parallel()
+
+		uploader := NewTelemetryUploader("some-url")
+		files, err := uploader.getTelemetryFiles(
+			context.Background(),
+			"testdata/telemetry-files",
+		)
+		require.NoError(t, err)
+		require.Equal(t, []string{"testdata/telemetry-files/shuttle-telemetry.jsonl"}, files)
+	})
+}


### PR DESCRIPTION
This feature adds a rudementary upload feature.

If SHUTTLE_REMOTE_TELEMETRY is enabled it will log to your local folder

I.e. SHUTTLE_REMOTE_TELEMETRY=default ~/.local/share/shuttle/telemetry

you can then use `shuttle telemetry upload` to actually upload the files to an endpoint at `SHUTTLE_REMOTE_TELEMETRY_URL`