### PR TITLE
feat: fix goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@ builds:
     goarch:
       - amd64
       - arm64
-      - 386
+      - "386"
     ldflags:
       - "-s -w -X github.com/lunarway/shuttle/cmd.version={{.Version}} -X github.com/lunarway/shuttle/cmd.commit={{.Commit}}"
 
@@ -15,11 +15,6 @@ archives:
   - id: archives
     format: binary
     name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
-    replacements:
-      darwin: darwin
-      linux: linux
-      windows: windows
-      386: i386
 
 checksum:
   name_template: "{{ .ProjectName }}-checksums.txt"


### PR DESCRIPTION
goreleaser removed some fields:

i386 shouldn't matter that much because it is 32bit binaries

https://github.com/goreleaser/goreleaser/blob/v1.17.1/pkg/config/config.go

vs 

https://github.com/goreleaser/goreleaser/blob/v1.19.0/pkg/config/config.go