### PR TITLE
fix: golang actions now work in go workspaces

### DIFF
--- a/examples/moon-base/actions/dev.go
+++ b/examples/moon-base/actions/dev.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	_ "github.com/lunarway/shuttle"
 )
 
 func Dev(ctx context.Context) error {

--- a/pkg/executors/golang/codegen/compilation.go
+++ b/pkg/executors/golang/codegen/compilation.go
@@ -2,6 +2,8 @@ package codegen
 
 import (
 	"context"
+	"log"
+	"os"
 	"os/exec"
 	"path"
 
@@ -10,11 +12,15 @@ import (
 
 func CompileBinary(ctx context.Context, ui *ui.UI, shuttlelocaldir string) (string, error) {
 	cmd := exec.Command("go", "build")
+	cmd.Env = os.Environ()
+	// We need to set workspaces off, as we don't want users to have to add the golang modules to their go.work
+	cmd.Env = append(cmd.Env, "GOWORK=off")
+
 	cmd.Dir = path.Join(shuttlelocaldir, "tmp")
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		ui.Verboseln("compile-binary output: %s", string(output))
+		log.Printf("compile-binary output: %s", string(output))
 		return "", err
 	}
 

--- a/pkg/executors/golang/compile/compile.go
+++ b/pkg/executors/golang/compile/compile.go
@@ -115,20 +115,20 @@ func compile(ctx context.Context, ui *ui.UI, actions *discover.ActionsDiscovered
 
 	if goInstalled() {
 		if err = codegen.Format(ctx, ui, shuttlelocaldir); err != nil {
-			return "", err
+			return "", fmt.Errorf("go fmt failed: %w", err)
 		}
 
 		if err = codegen.ModTidy(ctx, ui, shuttlelocaldir); err != nil {
-			return "", err
+			return "", fmt.Errorf("go mod tidy failed: %w", err)
 		}
 		binarypath, err = codegen.CompileBinary(ctx, ui, shuttlelocaldir)
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("go build failed: %w", err)
 		}
 	} else {
 		binarypath, err = compileWithDagger(ctx, ui, shuttlelocaldir)
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("failed to compile with dagger: %w", err)
 		}
 	}
 

--- a/pkg/executors/golang/executer/prepare.go
+++ b/pkg/executors/golang/executer/prepare.go
@@ -21,7 +21,7 @@ func prepare(
 
 	disc, err := discover.Discover(ctx, path, c)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fiscover actions: %v", err)
+		return nil, fmt.Errorf("failed to discover actions: %v", err)
 	}
 
 	binaries, err := compile.Compile(ctx, ui, disc)


### PR DESCRIPTION
Previously if a go.work (workspaces) exist, the build fails to compile, this is because we cannot do a proper build without the dependencies being shared between all the modules.

This sets GOWORK=off for only the internal builds
