### PR TITLE
fix/send normal output to stderr

### DIFF
--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -37,7 +37,7 @@ func TestConfig(t *testing.T) {
 			name:      "git plan",
 			input:     args("-p", "testdata/project-git", "config"),
 			stdoutput: "Version <dev-version>\nPlan:\nhttps://github.com/lunarway/shuttle-example-go-plan.git master\nEnvironment:\nVAR1=TEST1\nVAR2=TEST2\nVAR3=TEST3\n",
-			erroutput: "",
+			erroutput: "Cloning plan https://github.com/lunarway/shuttle-example-go-plan.git\n",
 			err:       nil,
 		},
 	}

--- a/cmd/plan_test.go
+++ b/cmd/plan_test.go
@@ -14,11 +14,10 @@ func TestPlan(t *testing.T) {
 			err:       nil,
 		},
 		{
-			name:  "git plan",
-			input: args("-p", "testdata/project-git", "plan"),
-			stdoutput: `Cloning plan https://github.com/lunarway/shuttle-example-go-plan.git
-https://github.com/lunarway/shuttle-example-go-plan.git`,
-			erroutput: "",
+			name:      "git plan",
+			input:     args("-p", "testdata/project-git", "plan"),
+			stdoutput: "https://github.com/lunarway/shuttle-example-go-plan.git",
+			erroutput: "Cloning plan https://github.com/lunarway/shuttle-example-go-plan.git\n",
 			err:       nil,
 		},
 		{

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -49,7 +49,7 @@ Global Flags:
 			name:      "std err echo",
 			input:     args("-p", "testdata/project", "run", "hello_stderr"),
 			stdoutput: "",
-			erroutput: "\x1b[31;1mHello stderr\x1b[0m\n",
+			erroutput: "Hello stderr\n",
 			err:       nil,
 		},
 		{
@@ -154,28 +154,24 @@ Make sure you are in a project using shuttle and that a 'shuttle.yaml' file is a
 			err: errors.New(`unknown flag: --a b`),
 		},
 		{
-			name:  "branched git plan",
-			input: args("-p", "testdata/project-git-branched", "run", "say"),
-			stdoutput: `Cloning plan https://github.com/lunarway/shuttle-example-go-plan.git
-something clever
-`,
-			erroutput: "",
+			name:      "branched git plan",
+			input:     args("-p", "testdata/project-git-branched", "run", "say"),
+			stdoutput: "something clever\n",
+			erroutput: "Cloning plan https://github.com/lunarway/shuttle-example-go-plan.git\n",
 			err:       nil,
 		},
 		{
-			name:  "git plan",
-			input: args("-p", "testdata/project-git", "run", "say"),
-			stdoutput: `Cloning plan https://github.com/lunarway/shuttle-example-go-plan.git
-something masterly
-`,
-			erroutput: "",
+			name:      "git plan",
+			input:     args("-p", "testdata/project-git", "run", "say"),
+			stdoutput: "something masterly\n",
+			erroutput: "Cloning plan https://github.com/lunarway/shuttle-example-go-plan.git\n",
 			initErr:   errors.New("something"),
 		},
 		{
 			name:      "tagged git plan",
 			input:     args("-p", "testdata/project-git", "--plan", "#tagged", "run", "say"),
-			stdoutput: "\x1b[032;1mOverload git plan branch/tag/sha with tagged\x1b[0m\nCloning plan https://github.com/lunarway/shuttle-example-go-plan.git\nsomething tagged\n",
-			erroutput: "",
+			stdoutput: "something tagged\n",
+			erroutput: "\x1b[032;1mOverload git plan branch/tag/sha with tagged\x1b[0m\nCloning plan https://github.com/lunarway/shuttle-example-go-plan.git\n",
 			err:       nil,
 		},
 		{
@@ -188,8 +184,8 @@ something masterly
 				"run",
 				"hello-plan",
 			),
-			stdoutput: "Using overloaded plan ./testdata/project-local/plan\nHello from plan\n",
-			erroutput: "",
+			stdoutput: "Hello from plan\n",
+			erroutput: "Using overloaded plan ./testdata/project-local/plan\n",
 			err:       nil,
 		},
 		// FIXME: This case actually hits a bug as we do not support fetching specific commits

--- a/pkg/executors/shell.go
+++ b/pkg/executors/shell.go
@@ -59,7 +59,7 @@ func executeShell(ctx context.Context, ui *ui.UI, context ActionExecutionContext
 					execCmd.Stdout = nil
 					continue
 				}
-				context.ScriptContext.Project.UI.Infoln("%s", line)
+				context.ScriptContext.Project.UI.Output("%s", line)
 			case line, open := <-execCmd.Stderr:
 				if !open {
 					execCmd.Stderr = nil

--- a/pkg/executors/shell.go
+++ b/pkg/executors/shell.go
@@ -65,7 +65,7 @@ func executeShell(ctx context.Context, ui *ui.UI, context ActionExecutionContext
 					execCmd.Stderr = nil
 					continue
 				}
-				context.ScriptContext.Project.UI.Errorln("%s", line)
+				context.ScriptContext.Project.UI.Infoln("%s", line)
 			}
 		}
 	}()

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -164,7 +164,7 @@ func GetGitPlan(
 			panic(fmt.Sprintf("Unknown protocol '%s'", parsedGitPlan.Protocol))
 		}
 
-		uii.Infoln("Cloning plan %s", cloneArg)
+		uii.Errorln("Cloning plan %s", cloneArg)
 		err = gitCmd(fmt.Sprintf("clone %v --branch %v plan", cloneArg, parsedGitPlan.Head), localShuttleDirectoryPath, uii)
 		if err != nil {
 			return "", err

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -164,7 +164,7 @@ func GetGitPlan(
 			panic(fmt.Sprintf("Unknown protocol '%s'", parsedGitPlan.Protocol))
 		}
 
-		uii.Errorln("Cloning plan %s", cloneArg)
+		uii.Infoln("Cloning plan %s", cloneArg)
 		err = gitCmd(fmt.Sprintf("clone %v --branch %v plan", cloneArg, parsedGitPlan.Head), localShuttleDirectoryPath, uii)
 		if err != nil {
 			return "", err

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -216,7 +216,7 @@ func RunGitPlanCommand(command string, plan string, uii *ui.UI) {
 					execCmd.Stdout = nil
 					continue
 				}
-				uii.Infoln("%s", line)
+				fmt.Printf("%s", line)
 			case line, open := <-execCmd.Stderr:
 				if !open {
 					execCmd.Stderr = nil

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -21,7 +21,7 @@ func Create(out, err io.Writer) *UI {
 		EffectiveLevel: LevelInfo,
 		DefaultLevel:   LevelInfo,
 		UserLevelSet:   false,
-		Out:            err,
+		Out:            out,
 		Err:            err,
 	}
 }
@@ -46,23 +46,28 @@ func (ui *UI) SetContext(level Level) *UI {
 	return ui
 }
 
+// Output.
+func (ui *UI) Output(format string, args ...interface{}) {
+	fmt.Fprintln(ui.Out, fmt.Sprintf(format, args...))
+}
+
 // Verboseln prints a formatted verbose message line.
 func (ui *UI) Verboseln(format string, args ...interface{}) {
 	if ui.EffectiveLevel.OutputIsIncluded(LevelVerbose) {
-		fmt.Fprintln(ui.Out, fmt.Sprintf(format, args...))
+		fmt.Fprintln(ui.Err, fmt.Sprintf(format, args...))
 	}
 }
 
 // Infoln prints a formatted info message line.
 func (ui *UI) Infoln(format string, args ...interface{}) {
 	if ui.EffectiveLevel.OutputIsIncluded(LevelInfo) {
-		fmt.Fprintln(ui.Out, fmt.Sprintf(format, args...))
+		fmt.Fprintln(ui.Err, fmt.Sprintf(format, args...))
 	}
 }
 
 func (ui *UI) EmphasizeInfoln(format string, args ...interface{}) {
 	if ui.EffectiveLevel.OutputIsIncluded(LevelInfo) {
-		fmt.Fprintf(ui.Out, "\x1b[032;1m%s\x1b[0m\n", fmt.Sprintf(format, args...))
+		fmt.Fprintf(ui.Err, "\x1b[032;1m%s\x1b[0m\n", fmt.Sprintf(format, args...))
 	}
 }
 

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -21,7 +21,7 @@ func Create(out, err io.Writer) *UI {
 		EffectiveLevel: LevelInfo,
 		DefaultLevel:   LevelInfo,
 		UserLevelSet:   false,
-		Out:            out,
+		Out:            err,
 		Err:            err,
 	}
 }


### PR DESCRIPTION
This pr redirects all output to be send via. stderr in ui.UI instead of stdout.

Stdout is supposed to be used for programs which should pipe to other programs.

Stderr, is supposed to be used for giving information to the user about the process. As such I've taken the libery of changing the shell.go exec from Errorln -> Infoln. This should remove the red text, as the output is technically not an error.

--- 

> @kjuulh :
> what are stdout and stderr supposed to be used for?


> chatgpt:
> stdout (standard output) and stderr (standard error) are two separate output streams used in computer programming, especially in Unix-like operating systems. They serve different purposes:
> 
> 1. stdout (Standard Output): This is the default output stream for data (like text) that a program is designed to produce. In most cases, this data is the main output of the program. For example, if you run a program to calculate something, the result of the calculation would be sent to stdout.
> 2. stderr (Standard Error): This is used specifically for outputting error messages and diagnostics. It's separate from `stdout so that error messages can be handled differently. For example, in a logging system, you might want to capture errors separately from regular output for debugging purposes.
>
> Separating these streams allows for more flexible handling of output. For instance, in a Unix command line, you can redirect stdout to a file, while still viewing stderr on the terminal, or vice versa. This separation is useful in debugging and log management in software development.
```
