### PR TITLE
feat: don't ask for optional but missing args

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -130,6 +130,10 @@ func newRunSubCommand(
 	// Decide whether to fall back on prompt or give a hard error
 	validateInputArgs := func(value config.ShuttlePlanScript, inputArgs map[string]*string) error {
 		for _, arg := range value.Args {
+			if !arg.Required {
+				continue
+			}
+
 			arg := arg
 
 			if *inputArgs[arg.Name] == "" && *interactiveArg {


### PR DESCRIPTION
This pr makes sure that we don't prompt for optional tokens when interactive. Otherwise people would just need to press enter 4 times in a row for no other benefit
