### PR TITLE
:bug: c.PlanRaw can be nil

### DIFF
--- a/pkg/config/shuttleconfig.go
+++ b/pkg/config/shuttleconfig.go
@@ -118,12 +118,21 @@ func (c *ShuttleConfig) getConf(projectPath string, strictConfigLookup bool) (st
 		)
 	}
 
+	if c.PlanRaw == nil {
+		return "", shuttleerrors.NewExitCode(
+			2,
+			"Failed to parse shuttle configuration: %s\n\nFailed to find a `plan`. Make sure your 'shuttle.yaml' is valid.",
+			err,
+		)
+	}
+
 	switch c.PlanRaw {
 	case false:
 		// no plan
 	default:
 		c.Plan = c.PlanRaw.(string)
 	}
+
 	// return the path where the shuttle.yaml file was found
 	return path.Dir(file.Name()), nil
 }


### PR DESCRIPTION
Hi Empowers!
I am getting a crash in Shuttle: https://github.com/lunarway/design-tokens/actions/runs/7009031830/job/19066620748?pr=17
The problem seems to be this piece of code in shuttleconfig.go:125 (Brilliantly found by reading the stacktrace)
The code crashing seems to be this:
```
switch c.PlanRaw {
    case false:
        // no plan
    default:
        c.Plan = c.PlanRaw.(string) // <-- this line to be specific
```

I assume this is a case that should be caught by the switch statement using what I assume is dark Go magic, instead of just doing a if c.PlanRaw == nil .

I am a bit unsure of what the right fix here is, besides just doing a nil check.

But this PR at least provides better logging in case this happens for someone else.