### PR TITLE
feat: add support for workspaces and external modules in the same repo

### DIFF
--- a/pkg/executors/golang/codegen/mod_file.go
+++ b/pkg/executors/golang/codegen/mod_file.go
@@ -1,0 +1,68 @@
+package codegen
+
+import (
+	"fmt"
+	"io/fs"
+	"path"
+	"strings"
+
+	"golang.org/x/exp/slices"
+)
+
+type actionsModFile struct {
+	info    fs.FileInfo
+	content []string
+	path    string
+
+	writeFileFunc writeFileFunc
+}
+
+func (a *actionsModFile) containsModule(moduleName string) bool {
+	return slices.ContainsFunc(a.content, func(s string) bool {
+		return strings.Contains(s, moduleName)
+	})
+}
+
+func (a *actionsModFile) replaceModulePath(rootDir string, module module) {
+	relativeToActionsModulePath := path.Join(strings.Repeat("../", a.segmentsTo(rootDir)), module.path)
+
+	foundReplace := false
+	for i, line := range a.content {
+		lineTrim := strings.TrimSpace(line)
+
+		if strings.Contains(lineTrim, fmt.Sprintf("replace %s", module.name)) {
+			a.content[i] = fmt.Sprintf("replace %s => %s", module.name, relativeToActionsModulePath)
+			foundReplace = true
+			break
+		}
+
+	}
+
+	if !foundReplace {
+		a.content = append(
+			a.content,
+			fmt.Sprintf("\nreplace %s => %s", module.name, relativeToActionsModulePath),
+		)
+
+	}
+}
+
+func (a *actionsModFile) segmentsTo(dirPath string) int {
+	relativeActionsModFilePath := strings.TrimPrefix(
+		strings.TrimPrefix(
+			a.path,
+			dirPath,
+		),
+		"/",
+	)
+
+	return strings.Count(relativeActionsModFilePath, "/")
+}
+
+func (a *actionsModFile) commit() error {
+	return a.writeFileFunc(
+		a.path,
+		[]byte(strings.Join(a.content, "\n")),
+		a.info.Mode(),
+	)
+}

--- a/pkg/executors/golang/codegen/mod_file_test.go
+++ b/pkg/executors/golang/codegen/mod_file_test.go
@@ -1,0 +1,247 @@
+package codegen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContainsModule(t *testing.T) {
+	t.Parallel()
+
+	sut := actionsModFile{
+		content: []string{
+			"someModuleName",
+			"someOtherModuleName",
+			"  someSpacedModule",
+			"package somePackaged",
+			"module someModModule",
+			"require someRequireModule",
+		},
+	}
+
+	t.Run("contains a module name", func(t *testing.T) {
+		actual := sut.containsModule("someModuleName")
+
+		assert.True(t, actual)
+	})
+
+	t.Run("does not contain module", func(t *testing.T) {
+		actual := sut.containsModule("someNonExistingModule")
+
+		assert.False(t, actual)
+	})
+
+	t.Run("spaced matches", func(t *testing.T) {
+		actual := sut.containsModule("someSpacedModule")
+
+		assert.True(t, actual)
+	})
+
+	t.Run("packaged matches", func(t *testing.T) {
+		actual := sut.containsModule("somePackaged")
+
+		assert.True(t, actual)
+	})
+
+	t.Run("modded module matches", func(t *testing.T) {
+		actual := sut.containsModule("someModModule")
+
+		assert.True(t, actual)
+	})
+
+	t.Run("required module matches", func(t *testing.T) {
+		actual := sut.containsModule("someRequireModule")
+
+		assert.True(t, actual)
+	})
+
+	t.Run("case sensitive doesn't match", func(t *testing.T) {
+		actual := sut.containsModule("SOMEMODULENAME")
+
+		assert.False(t, actual)
+	})
+}
+
+func TestReplaceModulePath(t *testing.T) {
+	t.Parallel()
+
+	createSut := func() actionsModFile {
+
+		modFileContent := `module actions
+
+require (
+	root_workspace v0.0.0
+	subpackage v0.0.0
+	othersubpackage v0.0.0
+)
+
+go 1.21.4
+
+replace othersubpackage => ../../../../othersubpackage`
+
+		return actionsModFile{
+			path:    "/some-path/some-other-path",
+			content: strings.Split(modFileContent, "\n"),
+		}
+
+	}
+
+	t.Run("module matches, not replaced already", func(t *testing.T) {
+		sut := createSut()
+
+		expected := `module actions
+
+require (
+	root_workspace v0.0.0
+	subpackage v0.0.0
+	othersubpackage v0.0.0
+)
+
+go 1.21.4
+
+replace othersubpackage => ../../../../othersubpackage
+
+replace subpackage => ../subpackage`
+
+		sut.replaceModulePath("some-other-path/newpath", module{
+			name: "subpackage",
+			path: "subpackage",
+		})
+
+		assert.Equal(t, expected, strings.Join(sut.content, "\n"))
+	})
+
+	t.Run("module matches, not replaced already, deeper nesting", func(t *testing.T) {
+		sut := createSut()
+
+		expected := `module actions
+
+require (
+	root_workspace v0.0.0
+	subpackage v0.0.0
+	othersubpackage v0.0.0
+)
+
+go 1.21.4
+
+replace othersubpackage => ../../../../othersubpackage
+
+replace subpackage => subpackage`
+
+		sut.replaceModulePath("/some-path", module{
+			name: "subpackage",
+			path: "subpackage",
+		})
+
+		assert.Equal(t, expected, strings.Join(sut.content, "\n"))
+	})
+
+	t.Run("module matches, already replaced already", func(t *testing.T) {
+		sut := createSut()
+
+		expected := `module actions
+
+require (
+	root_workspace v0.0.0
+	subpackage v0.0.0
+	othersubpackage v0.0.0
+)
+
+go 1.21.4
+
+replace othersubpackage => ../othersubpackage`
+
+		sut.replaceModulePath("some-other-path/newpath", module{
+			name: "othersubpackage",
+			path: "othersubpackage",
+		})
+
+		assert.Equal(t, expected, strings.Join(sut.content, "\n"))
+	})
+
+	t.Run("module matches, already replaced already deeper nesting", func(t *testing.T) {
+		sut := createSut()
+
+		expected := `module actions
+
+require (
+	root_workspace v0.0.0
+	subpackage v0.0.0
+	othersubpackage v0.0.0
+)
+
+go 1.21.4
+
+replace othersubpackage => othersubpackage`
+
+		sut.replaceModulePath("/some-path", module{
+			name: "othersubpackage",
+			path: "othersubpackage",
+		})
+
+		assert.Equal(t, expected, strings.Join(sut.content, "\n"))
+	})
+}
+
+func TestSegmentsTo(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		path     string
+		rootDir  string
+		expected int
+	}{
+		{
+			name:     "empty",
+			path:     "",
+			rootDir:  "",
+			expected: 0,
+		},
+		{
+			name:     "current dir",
+			path:     "/some-dir/",
+			rootDir:  "/some-dir/",
+			expected: 0,
+		},
+		{
+			name:     "one level",
+			path:     "/some-dir/some-other-dir/",
+			rootDir:  "/some-dir",
+			expected: 1,
+		},
+		{
+			name:     "2 level",
+			path:     "/some-dir/some-other-dir/some-third-dir/",
+			rootDir:  "/some-dir",
+			expected: 2,
+		},
+		{
+			name:     "1 level",
+			path:     "/some-dir/some-other-dir/some-third-dir/",
+			rootDir:  "/some-dir/some-other-dir",
+			expected: 1,
+		},
+		{
+			name:     "without trailing",
+			path:     "/some-dir/some-third-dir",
+			rootDir:  "/some-dir",
+			expected: 0,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			sut := actionsModFile{
+				path: testCase.path,
+			}
+
+			actual := sut.segmentsTo(testCase.rootDir)
+
+			assert.Equal(t, testCase.expected, actual)
+		})
+	}
+
+}

--- a/pkg/executors/golang/codegen/module.go
+++ b/pkg/executors/golang/codegen/module.go
@@ -1,0 +1,27 @@
+package codegen
+
+import (
+	"strings"
+
+	"golang.org/x/exp/slices"
+)
+
+type module struct {
+	name string
+	path string
+}
+
+func modulesFromMap(packages map[string]string) []module {
+	modules := make([]module, 0, len(packages))
+	for moduleName, modulePath := range packages {
+		modules = append(modules, module{
+			name: moduleName,
+			path: modulePath,
+		})
+	}
+	slices.SortFunc(modules, func(a, b module) int {
+		return strings.Compare(a.name, b.name)
+	})
+
+	return modules
+}

--- a/pkg/executors/golang/codegen/patch.go
+++ b/pkg/executors/golang/codegen/patch.go
@@ -1,0 +1,130 @@
+package codegen
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"strings"
+)
+
+type writeFileFunc = func(name string, contents []byte, permissions fs.FileMode) error
+
+func PatchGoMod(rootDir string, shuttleLocalDir string) error {
+	fmt.Printf("dirs: %s %s\n", rootDir, shuttleLocalDir)
+
+	return patchGoMod(
+		rootDir,
+		shuttleLocalDir,
+		os.WriteFile,
+	)
+}
+
+func patchGoMod(rootDir, shuttleLocalDir string, writeFileFunc writeFileFunc) error {
+	packages := make(map[string]string, 0)
+
+	if rootModExists(rootDir) {
+		moduleName, modulePath, err := GetRootModule(rootDir)
+		if err != nil {
+			return fmt.Errorf("failed to parse go.mod in root of project: %w", err)
+		}
+
+		packages[moduleName] = modulePath
+	}
+
+	if err := patchPackagesUsed(rootDir, shuttleLocalDir, packages, writeFileFunc); err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+func patchPackagesUsed(rootDir string, shuttleLocalDir string, packages map[string]string, writeFileFunc writeFileFunc) error {
+	actionsModFilePath := path.Join(shuttleLocalDir, "tmp/go.mod")
+	segmentsToRoot := strings.Count(path.Join(strings.TrimPrefix(rootDir, shuttleLocalDir), "tmp/go.mod"), "/")
+	actionsModFileContents, err := os.ReadFile(actionsModFilePath)
+	if err != nil {
+		return err
+	}
+	actionsModFilePermissions, err := os.Stat(actionsModFilePath)
+	if err != nil {
+		return err
+	}
+
+	actionsModFile := string(actionsModFileContents)
+	actionsFileWriter := bytes.NewBufferString(actionsModFile)
+
+	actionsModFileContainsModule := func(moduleName string) bool {
+		return strings.Contains(actionsModFile, moduleName)
+	}
+
+	for moduleName, modulePath := range packages {
+		if !actionsModFileContainsModule(moduleName) {
+			continue
+		}
+
+		relativeToActionsModulePath := path.Join(strings.Repeat("../", segmentsToRoot), modulePath)
+
+		_, err := fmt.Fprintf(actionsFileWriter, "\nreplace %s => %s\n", moduleName, relativeToActionsModulePath)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = writeFileFunc(actionsModFilePath, actionsFileWriter.Bytes(), actionsModFilePermissions.Mode())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func GetRootModule(rootDir string) (moduleName string, modulePath string, err error) {
+	modFile, err := os.ReadFile(path.Join(rootDir, "go.mod"))
+	if err != nil {
+		return "", "", err
+	}
+
+	modFileContent := string(modFile)
+	lines := strings.Split(modFileContent, "\n")
+	if len(lines) == 0 {
+		return "", "", errors.New("go mod is empty")
+	}
+
+	for _, line := range lines {
+		modFileLine := strings.TrimSpace(line)
+		if strings.HasPrefix(modFileLine, "module") {
+			sections := strings.Split(modFileLine, " ")
+			if len(sections) < 2 {
+				return "", "", fmt.Errorf("invalid module line: %s", modFileLine)
+			}
+
+			moduleName := sections[1]
+
+			return moduleName, ".", nil
+		}
+	}
+
+	return "", "", errors.New("failed to find a valid go.mod file")
+}
+
+func rootModExists(rootDir string) bool {
+	goMod := path.Join(rootDir, "go.mod")
+	if _, err := os.Stat(goMod); errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+
+	return true
+}
+
+func rootWorkspaceExists() bool {
+	goWork := "go.work"
+	if _, err := os.Stat(goWork); errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+
+	return true
+}

--- a/pkg/executors/golang/codegen/patch.go
+++ b/pkg/executors/golang/codegen/patch.go
@@ -15,7 +15,7 @@ type Patcher struct {
 
 func NewPatcher() *Patcher {
 	return &Patcher{
-		patchFinder: newChainedwPatchFinder(
+		patchFinder: newChainedPatchFinder(
 			newWorkspaceFinder(),
 			newGoModuleFinder(),
 			newDefaultFinder(),

--- a/pkg/executors/golang/codegen/patch.go
+++ b/pkg/executors/golang/codegen/patch.go
@@ -1,116 +1,36 @@
 package codegen
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"io/fs"
 	"os"
-	"path"
-	"strings"
-
-	"github.com/lunarway/shuttle/pkg/ui"
 )
 
 type writeFileFunc = func(name string, contents []byte, permissions fs.FileMode) error
 
-func PatchGoMod(ctx context.Context, rootDir string, shuttleLocalDir string) error {
-	return patchGoMod(
-		ctx,
-		rootDir,
-		shuttleLocalDir,
-		ui,
-		os.WriteFile,
-	)
+type Patcher struct {
+	patchFinder *chainedPackageFinder
+	patcher     *goModPatcher
 }
 
-func patchGoMod(ctx context.Context, rootDir, shuttleLocalDir string, writeFileFunc writeFileFunc) error {
-	packages, err := newChainedwPatchFinder(
-		newWorkspaceFinder(rootDir),
-		newGoModuleFinder(rootDir),
-		newDefaultFinder(),
-	).findPackages(ctx)
+func NewPatcher() *Patcher {
+	return &Patcher{
+		patchFinder: newChainedwPatchFinder(
+			newWorkspaceFinder(),
+			newGoModuleFinder(),
+			newDefaultFinder(),
+		),
+		patcher: newGoModPatcher(os.WriteFile),
+	}
+}
+
+func (p *Patcher) Patch(ctx context.Context, rootDir string, shuttleLocalDir string) error {
+	packages, err := p.patchFinder.findPackages(ctx, rootDir)
 	if err != nil {
 		return err
 	}
 
-	if err := newGoModPatcher(writeFileFunc).patchPackagesUsed(rootDir, shuttleLocalDir, packages); err != nil {
-		return err
-	}
-
-	return nil
-
-}
-
-// packageFinder exists to find whatever patches are required for a given shuttle golang action to function
-type packageFinder interface {
-	// Find should return how many packages are required to function
-	Find(ctx context.Context) (packages map[string]string, ok bool, err error)
-}
-
-type goModPatcher struct {
-	writeFileFunc writeFileFunc
-}
-
-func newGoModPatcher(writeFileFunc writeFileFunc) *goModPatcher {
-	return &goModPatcher{writeFileFunc: writeFileFunc}
-}
-
-func (p *goModPatcher) patchPackagesUsed(rootDir string, shuttleLocalDir string, packages map[string]string) error {
-	actionsModFilePath := path.Join(shuttleLocalDir, "tmp/go.mod")
-	relativeActionsModFilePath := strings.TrimPrefix(path.Join(strings.TrimPrefix(shuttleLocalDir, rootDir), "tmp/go.mod"), "/")
-	segmentsToRoot := strings.Count(relativeActionsModFilePath, "/")
-
-	actionsModFileContents, err := os.ReadFile(actionsModFilePath)
-	if err != nil {
-		return err
-	}
-	actionsModFilePermissions, err := os.Stat(actionsModFilePath)
-	if err != nil {
-		return err
-	}
-
-	actionsModFile := string(actionsModFileContents)
-	actionsModFileLines := strings.Split(actionsModFile, "\n")
-
-	actionsModFileContainsModule := func(moduleName string) bool {
-		return strings.Contains(actionsModFile, moduleName)
-	}
-
-	for moduleName, modulePath := range packages {
-		if !actionsModFileContainsModule(moduleName) {
-			continue
-		}
-
-		relativeToActionsModulePath := path.Join(strings.Repeat("../", segmentsToRoot), modulePath)
-
-		foundReplace := false
-		for i, line := range actionsModFileLines {
-			lineTrim := strings.TrimSpace(line)
-
-			if strings.Contains(lineTrim, fmt.Sprintf("replace %s", moduleName)) {
-				actionsModFileLines[i] = fmt.Sprintf("replace %s => %s", moduleName, relativeToActionsModulePath)
-				foundReplace = true
-				break
-			}
-		}
-
-		if !foundReplace {
-			actionsModFileLines = append(
-				actionsModFileLines,
-				fmt.Sprintf("\nreplace %s => %s", moduleName, relativeToActionsModulePath),
-			)
-
-		}
-
-		if err != nil {
-			return err
-		}
-	}
-
-	actionsFileWriter := bytes.NewBufferString(strings.Join(actionsModFileLines, "\n"))
-	err = p.writeFileFunc(actionsModFilePath, actionsFileWriter.Bytes(), actionsModFilePermissions.Mode())
-	if err != nil {
+	if err := p.patcher.patch(rootDir, shuttleLocalDir, packages); err != nil {
 		return err
 	}
 

--- a/pkg/executors/golang/codegen/patch_default.go
+++ b/pkg/executors/golang/codegen/patch_default.go
@@ -1,0 +1,14 @@
+package codegen
+
+import "context"
+
+type defaultFinder struct{}
+
+func newDefaultFinder() *defaultFinder {
+	return &defaultFinder{}
+}
+
+func (s *defaultFinder) Find(ctx context.Context) (packages map[string]string, ok bool, err error) {
+	// We return true, as this should be placed last in the chain
+	return make(map[string]string, 0), true, nil
+}

--- a/pkg/executors/golang/codegen/patch_default.go
+++ b/pkg/executors/golang/codegen/patch_default.go
@@ -8,7 +8,7 @@ func newDefaultFinder() *defaultFinder {
 	return &defaultFinder{}
 }
 
-func (s *defaultFinder) Find(ctx context.Context) (packages map[string]string, ok bool, err error) {
+func (s *defaultFinder) Find(ctx context.Context, _ string) (packages map[string]string, ok bool, err error) {
 	// We return true, as this should be placed last in the chain
 	return make(map[string]string, 0), true, nil
 }

--- a/pkg/executors/golang/codegen/patch_finder.go
+++ b/pkg/executors/golang/codegen/patch_finder.go
@@ -15,7 +15,7 @@ type chainedPackageFinder struct {
 	finders []packageFinder
 }
 
-func newChainedwPatchFinder(finders ...packageFinder) *chainedPackageFinder {
+func newChainedPatchFinder(finders ...packageFinder) *chainedPackageFinder {
 	return &chainedPackageFinder{
 		finders: finders,
 	}

--- a/pkg/executors/golang/codegen/patch_finder.go
+++ b/pkg/executors/golang/codegen/patch_finder.go
@@ -5,6 +5,12 @@ import (
 	"errors"
 )
 
+// packageFinder exists to find whatever patches are required for a given shuttle golang action to function
+type packageFinder interface {
+	// Find should return how many packages are required to function
+	Find(ctx context.Context, rootDir string) (packages map[string]string, ok bool, err error)
+}
+
 type chainedPackageFinder struct {
 	finders []packageFinder
 }
@@ -17,9 +23,9 @@ func newChainedwPatchFinder(finders ...packageFinder) *chainedPackageFinder {
 
 // FindPackages is setup as a chain of responsibility, which means that from most significant it will attempt to find packages
 // to be used. However, each finder needs to return how many packages it needs to function, as returning ok means that the finder has exclusive access to the packages
-func (p *chainedPackageFinder) findPackages(ctx context.Context) (packages map[string]string, err error) {
+func (p *chainedPackageFinder) findPackages(ctx context.Context, rootDir string) (packages map[string]string, err error) {
 	for _, finder := range p.finders {
-		packages, ok, err := finder.Find(ctx)
+		packages, ok, err := finder.Find(ctx, rootDir)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/executors/golang/codegen/patch_finder.go
+++ b/pkg/executors/golang/codegen/patch_finder.go
@@ -1,0 +1,32 @@
+package codegen
+
+import (
+	"context"
+	"errors"
+)
+
+type chainedPackageFinder struct {
+	finders []packageFinder
+}
+
+func newChainedwPatchFinder(finders ...packageFinder) *chainedPackageFinder {
+	return &chainedPackageFinder{
+		finders: finders,
+	}
+}
+
+// FindPackages is setup as a chain of responsibility, which means that from most significant it will attempt to find packages
+// to be used. However, each finder needs to return how many packages it needs to function, as returning ok means that the finder has exclusive access to the packages
+func (p *chainedPackageFinder) findPackages(ctx context.Context) (packages map[string]string, err error) {
+	for _, finder := range p.finders {
+		packages, ok, err := finder.Find(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			return packages, nil
+		}
+	}
+
+	return nil, errors.New("failed to find a valid patcher")
+}

--- a/pkg/executors/golang/codegen/patch_gomodule.go
+++ b/pkg/executors/golang/codegen/patch_gomodule.go
@@ -1,0 +1,74 @@
+package codegen
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+)
+
+type goModuleFinder struct {
+	rootDir string
+}
+
+func newGoModuleFinder(rootDir string) *goModuleFinder {
+	return &goModuleFinder{
+		rootDir: rootDir,
+	}
+}
+
+func (s *goModuleFinder) Find(ctx context.Context) (packages map[string]string, ok bool, err error) {
+	if !s.rootModExists() {
+		return nil, false, nil
+	}
+
+	moduleName, modulePath, err := s.getRootModule()
+	if err != nil {
+		return nil, true, fmt.Errorf("failed to parse go.mod in root of project: %w", err)
+	}
+
+	packages = make(map[string]string, 0)
+	packages[moduleName] = modulePath
+
+	return packages, true, nil
+}
+
+func (g *goModuleFinder) getRootModule() (moduleName string, modulePath string, err error) {
+	modFile, err := os.ReadFile(path.Join(g.rootDir, "go.mod"))
+	if err != nil {
+		return "", "", err
+	}
+
+	modFileContent := string(modFile)
+	lines := strings.Split(modFileContent, "\n")
+	if len(lines) == 0 {
+		return "", "", errors.New("go mod is empty")
+	}
+
+	for _, line := range lines {
+		modFileLine := strings.TrimSpace(line)
+		if strings.HasPrefix(modFileLine, "module") {
+			sections := strings.Split(modFileLine, " ")
+			if len(sections) < 2 {
+				return "", "", fmt.Errorf("invalid module line: %s", modFileLine)
+			}
+
+			moduleName := sections[1]
+
+			return moduleName, ".", nil
+		}
+	}
+
+	return "", "", errors.New("failed to find a valid go.mod file")
+}
+
+func (g *goModuleFinder) rootModExists() bool {
+	goMod := path.Join(g.rootDir, "go.mod")
+	if _, err := os.Stat(goMod); errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+
+	return true
+}

--- a/pkg/executors/golang/codegen/patch_gomodule.go
+++ b/pkg/executors/golang/codegen/patch_gomodule.go
@@ -24,13 +24,13 @@ func (s *goModuleFinder) Find(ctx context.Context, rootDir string) (packages map
 		return nil, false, nil
 	}
 
-	moduleName, modulePath, err := s.getModuleFromModFile(contents)
+	moduleName, err := s.getModuleFromModFile(contents)
 	if err != nil {
 		return nil, true, fmt.Errorf("failed to parse go.mod in root of project: %w", err)
 	}
 
 	packages = make(map[string]string, 0)
-	packages[moduleName] = modulePath
+	packages[moduleName] = ""
 
 	return packages, true, nil
 }
@@ -59,20 +59,20 @@ func (g *goModuleFinder) getGoModFile(rootDir string) (contents []string, ok boo
 	return lines, true, nil
 }
 
-func (g *goModuleFinder) getModuleFromModFile(contents []string) (moduleName string, modulePath string, err error) {
+func (g *goModuleFinder) getModuleFromModFile(contents []string) (moduleName string, err error) {
 	for _, line := range contents {
 		modFileLine := strings.TrimSpace(line)
 		if strings.HasPrefix(modFileLine, "module") {
 			sections := strings.Split(modFileLine, " ")
 			if len(sections) < 2 {
-				return "", "", fmt.Errorf("invalid module line: %s", modFileLine)
+				return "", fmt.Errorf("invalid module line: %s", modFileLine)
 			}
 
 			moduleName := sections[1]
 
-			return moduleName, ".", nil
+			return moduleName, nil
 		}
 	}
 
-	return "", "", errors.New("failed to find a valid go.mod file")
+	return "", errors.New("failed to find a valid go.mod file")
 }

--- a/pkg/executors/golang/codegen/patch_gomodule.go
+++ b/pkg/executors/golang/codegen/patch_gomodule.go
@@ -9,22 +9,18 @@ import (
 	"strings"
 )
 
-type goModuleFinder struct {
-	rootDir string
+type goModuleFinder struct{}
+
+func newGoModuleFinder() *goModuleFinder {
+	return &goModuleFinder{}
 }
 
-func newGoModuleFinder(rootDir string) *goModuleFinder {
-	return &goModuleFinder{
-		rootDir: rootDir,
-	}
-}
-
-func (s *goModuleFinder) Find(ctx context.Context) (packages map[string]string, ok bool, err error) {
-	if !s.rootModExists() {
+func (s *goModuleFinder) Find(ctx context.Context, rootDir string) (packages map[string]string, ok bool, err error) {
+	if !s.rootModExists(rootDir) {
 		return nil, false, nil
 	}
 
-	moduleName, modulePath, err := s.getRootModule()
+	moduleName, modulePath, err := s.getRootModule(rootDir)
 	if err != nil {
 		return nil, true, fmt.Errorf("failed to parse go.mod in root of project: %w", err)
 	}
@@ -35,8 +31,8 @@ func (s *goModuleFinder) Find(ctx context.Context) (packages map[string]string, 
 	return packages, true, nil
 }
 
-func (g *goModuleFinder) getRootModule() (moduleName string, modulePath string, err error) {
-	modFile, err := os.ReadFile(path.Join(g.rootDir, "go.mod"))
+func (g *goModuleFinder) getRootModule(rootDir string) (moduleName string, modulePath string, err error) {
+	modFile, err := os.ReadFile(path.Join(rootDir, "go.mod"))
 	if err != nil {
 		return "", "", err
 	}
@@ -64,8 +60,8 @@ func (g *goModuleFinder) getRootModule() (moduleName string, modulePath string, 
 	return "", "", errors.New("failed to find a valid go.mod file")
 }
 
-func (g *goModuleFinder) rootModExists() bool {
-	goMod := path.Join(g.rootDir, "go.mod")
+func (g *goModuleFinder) rootModExists(rootDir string) bool {
+	goMod := path.Join(rootDir, "go.mod")
 	if _, err := os.Stat(goMod); errors.Is(err, os.ErrNotExist) {
 		return false
 	}

--- a/pkg/executors/golang/codegen/patch_patcher.go
+++ b/pkg/executors/golang/codegen/patch_patcher.go
@@ -1,0 +1,100 @@
+package codegen
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"golang.org/x/exp/slices"
+)
+
+type module struct {
+	name string
+	path string
+}
+
+func modulesFromMap(packages map[string]string) []module {
+	modules := make([]module, 0, len(packages))
+	for moduleName, modulePath := range packages {
+		modules = append(modules, module{
+			name: moduleName,
+			path: modulePath,
+		})
+	}
+	slices.SortFunc(modules, func(a, b module) int {
+		return strings.Compare(a.name, b.name)
+	})
+
+	return modules
+}
+
+type goModPatcher struct {
+	writeFileFunc writeFileFunc
+}
+
+func newGoModPatcher(writeFileFunc writeFileFunc) *goModPatcher {
+	return &goModPatcher{writeFileFunc: writeFileFunc}
+}
+
+func (p *goModPatcher) patch(rootDir string, shuttleLocalDir string, packages map[string]string) error {
+	actionsModFilePath := path.Join(shuttleLocalDir, "tmp/go.mod")
+	relativeActionsModFilePath := strings.TrimPrefix(path.Join(strings.TrimPrefix(shuttleLocalDir, rootDir), "tmp/go.mod"), "/")
+
+	segmentsToRoot := strings.Count(relativeActionsModFilePath, "/")
+	actionsModFileContents, err := os.ReadFile(actionsModFilePath)
+	if err != nil {
+		return err
+	}
+	actionsModFilePermissions, err := os.Stat(actionsModFilePath)
+	if err != nil {
+		return err
+	}
+
+	actionsModFile := string(actionsModFileContents)
+	actionsModFileLines := strings.Split(actionsModFile, "\n")
+
+	actionsModFileContainsModule := func(moduleName string) bool {
+		return strings.Contains(actionsModFile, moduleName)
+	}
+
+	for _, module := range modulesFromMap(packages) {
+		if !actionsModFileContainsModule(module.name) {
+			continue
+		}
+
+		relativeToActionsModulePath := path.Join(strings.Repeat("../", segmentsToRoot), module.path)
+
+		foundReplace := false
+		for i, line := range actionsModFileLines {
+			lineTrim := strings.TrimSpace(line)
+
+			if strings.Contains(lineTrim, fmt.Sprintf("replace %s", module.name)) {
+				actionsModFileLines[i] = fmt.Sprintf("replace %s => %s", module.name, relativeToActionsModulePath)
+				foundReplace = true
+				break
+			}
+		}
+
+		if !foundReplace {
+			actionsModFileLines = append(
+				actionsModFileLines,
+				fmt.Sprintf("\nreplace %s => %s", module.name, relativeToActionsModulePath),
+			)
+
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+
+	actionsFileWriter := bytes.NewBufferString(strings.Join(actionsModFileLines, "\n"))
+	err = p.writeFileFunc(actionsModFilePath, actionsFileWriter.Bytes(), actionsModFilePermissions.Mode())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/executors/golang/codegen/patch_patcher.go
+++ b/pkg/executors/golang/codegen/patch_patcher.go
@@ -1,13 +1,9 @@
 package codegen
 
 import (
-	"fmt"
-	"io/fs"
 	"os"
 	"path"
 	"strings"
-
-	"golang.org/x/exp/slices"
 )
 
 type goModPatcher struct {
@@ -56,82 +52,4 @@ func (g *goModPatcher) readActionsMod(shuttleLocalDir string) (*actionsModFile, 
 
 		writeFileFunc: g.writeFileFunc,
 	}, nil
-}
-
-type actionsModFile struct {
-	info    fs.FileInfo
-	content []string
-	path    string
-
-	writeFileFunc writeFileFunc
-}
-
-func (a *actionsModFile) containsModule(moduleName string) bool {
-	return slices.ContainsFunc(a.content, func(s string) bool {
-		return strings.Contains(s, moduleName)
-	})
-}
-
-func (a *actionsModFile) replaceModulePath(rootDir string, module module) {
-	relativeToActionsModulePath := path.Join(strings.Repeat("../", a.segmentsTo(rootDir)), module.path)
-
-	foundReplace := false
-	for i, line := range a.content {
-		lineTrim := strings.TrimSpace(line)
-
-		if strings.Contains(lineTrim, fmt.Sprintf("replace %s", module.name)) {
-			a.content[i] = fmt.Sprintf("replace %s => %s", module.name, relativeToActionsModulePath)
-			foundReplace = true
-			break
-		}
-
-	}
-
-	if !foundReplace {
-		a.content = append(
-			a.content,
-			fmt.Sprintf("\nreplace %s => %s", module.name, relativeToActionsModulePath),
-		)
-
-	}
-}
-
-func (a *actionsModFile) segmentsTo(dirPath string) int {
-	relativeActionsModFilePath := strings.TrimPrefix(
-		strings.TrimPrefix(
-			a.path,
-			dirPath,
-		),
-		"/",
-	)
-
-	return strings.Count(relativeActionsModFilePath, "/")
-}
-
-func (a *actionsModFile) commit() error {
-	return a.writeFileFunc(
-		a.path,
-		[]byte(strings.Join(a.content, "\n")),
-		a.info.Mode(),
-	)
-}
-
-type module struct {
-	name string
-	path string
-}
-
-func modulesFromMap(packages map[string]string) []module {
-	modules := make([]module, 0, len(packages))
-	for moduleName, modulePath := range packages {
-		modules = append(modules, module{
-			name: moduleName,
-			path: modulePath,
-		})
-	}
-	slices.SortFunc(modules, func(a, b module) int {
-		return strings.Compare(a.name, b.name)
-	})
-
-	return modules
 }

--- a/pkg/executors/golang/codegen/patch_test.go
+++ b/pkg/executors/golang/codegen/patch_test.go
@@ -1,6 +1,7 @@
 package codegen
 
 import (
+	"context"
 	"io/fs"
 	"testing"
 
@@ -12,7 +13,8 @@ func TestPatchGoMod(t *testing.T) {
 	t.Parallel()
 
 	t.Run("finds root module adds to actions plan", func(t *testing.T) {
-		err := patchGoMod("testdata/patch/root_module/", "testdata/patch/root_module/.shuttle/actions", func(name string, contents []byte, permissions fs.FileMode) error {
+		sut := NewPatcher()
+		sut.patcher = newGoModPatcher(func(name string, contents []byte, permissions fs.FileMode) error {
 			assert.Equal(t, "testdata/patch/root_module/.shuttle/actions/tmp/go.mod", name)
 			assert.Equal(t, `module actions
 
@@ -27,11 +29,14 @@ replace root_module => ../../..`, string(contents))
 
 			return nil
 		})
+
+		err := sut.Patch(context.Background(), "testdata/patch/root_module/", "testdata/patch/root_module/.shuttle/actions")
 		require.NoError(t, err)
 	})
 
 	t.Run("finds root module replaces existing", func(t *testing.T) {
-		err := patchGoMod("testdata/patch/replace_existing/", "testdata/patch/replace_existing/.shuttle/actions", func(name string, contents []byte, permissions fs.FileMode) error {
+		sut := NewPatcher()
+		sut.patcher = newGoModPatcher(func(name string, contents []byte, permissions fs.FileMode) error {
 			assert.Equal(t, "testdata/patch/replace_existing/.shuttle/actions/tmp/go.mod", name)
 			assert.Equal(t, `module actions
 
@@ -46,11 +51,14 @@ replace replace_existing => ../../..
 
 			return nil
 		})
+
+		err := sut.Patch(context.Background(), "testdata/patch/replace_existing/", "testdata/patch/replace_existing/.shuttle/actions")
 		require.NoError(t, err)
 	})
 
 	t.Run("finds root workspace adds entries", func(t *testing.T) {
-		err := patchGoMod("testdata/patch/root_workspace/", "testdata/patch/root_workspace/.shuttle/actions", func(name string, contents []byte, permissions fs.FileMode) error {
+		sut := NewPatcher()
+		sut.patcher = newGoModPatcher(func(name string, contents []byte, permissions fs.FileMode) error {
 			assert.Equal(t, "testdata/patch/root_workspace/.shuttle/actions/tmp/go.mod", name)
 			assert.Equal(t, `module actions
 
@@ -63,14 +71,16 @@ require (
 go 1.21.4
 
 
+replace othersubpackage => ../../../other/subpackage
+
 replace root_workspace => ../../..
 
-replace subpackage => ../../../subpackage
-
-replace othersubpackage => ../../../other/subpackage`, string(contents))
+replace subpackage => ../../../subpackage`, string(contents))
 
 			return nil
 		})
+
+		err := sut.Patch(context.Background(), "testdata/patch/root_workspace/", "testdata/patch/root_workspace/.shuttle/actions")
 		require.NoError(t, err)
 	})
 }

--- a/pkg/executors/golang/codegen/patch_test.go
+++ b/pkg/executors/golang/codegen/patch_test.go
@@ -1,0 +1,32 @@
+package codegen
+
+import (
+	"io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPatchGoMod(t *testing.T) {
+	t.Parallel()
+
+	t.Run("finds root module adds to actions plan", func(t *testing.T) {
+		err := patchGoMod("testdata/patch/root_module/", ".shuttle/actions", func(name string, contents []byte, permissions fs.FileMode) error {
+			assert.Equal(t, "testdata/patch/root_module/.shuttle/actions/tmp/go.mod", name)
+			assert.Equal(t, `module actions
+
+require (
+	root_module
+)
+
+go 1.21.4
+
+replace root_module => ../../..
+`, string(contents))
+
+			return nil
+		})
+		require.NoError(t, err)
+	})
+}

--- a/pkg/executors/golang/codegen/patch_test.go
+++ b/pkg/executors/golang/codegen/patch_test.go
@@ -12,7 +12,7 @@ func TestPatchGoMod(t *testing.T) {
 	t.Parallel()
 
 	t.Run("finds root module adds to actions plan", func(t *testing.T) {
-		err := patchGoMod("testdata/patch/root_module/", ".shuttle/actions", func(name string, contents []byte, permissions fs.FileMode) error {
+		err := patchGoMod("testdata/patch/root_module/", "testdata/patch/root_module/.shuttle/actions", func(name string, contents []byte, permissions fs.FileMode) error {
 			assert.Equal(t, "testdata/patch/root_module/.shuttle/actions/tmp/go.mod", name)
 			assert.Equal(t, `module actions
 
@@ -22,7 +22,7 @@ require (
 
 go 1.21.4
 
-replace root_module => ../../..
+replace root_module => ../../../..
 `, string(contents))
 
 			return nil

--- a/pkg/executors/golang/codegen/patch_test.go
+++ b/pkg/executors/golang/codegen/patch_test.go
@@ -22,7 +22,26 @@ require (
 
 go 1.21.4
 
-replace root_module => ../../../..
+
+replace root_module => ../..`, string(contents))
+
+			return nil
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("finds root module replaces existing", func(t *testing.T) {
+		err := patchGoMod("testdata/patch/replace_existing/", "testdata/patch/replace_existing/.shuttle/actions", func(name string, contents []byte, permissions fs.FileMode) error {
+			assert.Equal(t, "testdata/patch/replace_existing/.shuttle/actions/tmp/go.mod", name)
+			assert.Equal(t, `module actions
+
+require (
+	replace_existing v0.0.0
+)
+
+go 1.21.4
+
+replace replace_existing => ../..
 `, string(contents))
 
 			return nil

--- a/pkg/executors/golang/codegen/patch_test.go
+++ b/pkg/executors/golang/codegen/patch_test.go
@@ -23,7 +23,7 @@ require (
 go 1.21.4
 
 
-replace root_module => ../..`, string(contents))
+replace root_module => ../../..`, string(contents))
 
 			return nil
 		})
@@ -41,8 +41,33 @@ require (
 
 go 1.21.4
 
-replace replace_existing => ../..
+replace replace_existing => ../../..
 `, string(contents))
+
+			return nil
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("finds root workspace adds entries", func(t *testing.T) {
+		err := patchGoMod("testdata/patch/root_workspace/", "testdata/patch/root_workspace/.shuttle/actions", func(name string, contents []byte, permissions fs.FileMode) error {
+			assert.Equal(t, "testdata/patch/root_workspace/.shuttle/actions/tmp/go.mod", name)
+			assert.Equal(t, `module actions
+
+require (
+	root_workspace v0.0.0
+	subpackage v0.0.0
+	othersubpackage v0.0.0
+)
+
+go 1.21.4
+
+
+replace root_workspace => ../../..
+
+replace subpackage => ../../../subpackage
+
+replace othersubpackage => ../../../other/subpackage`, string(contents))
 
 			return nil
 		})

--- a/pkg/executors/golang/codegen/patch_workspace.go
+++ b/pkg/executors/golang/codegen/patch_workspace.go
@@ -99,6 +99,17 @@ func (w *workspaceFinder) getWorkspaceModule(rootDir string, absoluteModulePath 
 			modulePath = strings.TrimPrefix(absoluteModulePath, rootDir)
 
 			return moduleName, modulePath, nil
+		} else if strings.HasPrefix(modFileLine, "use") && strings.Contains(modFileLine, ".") {
+			sections := strings.Split(modFileLine, " ")
+			if len(sections) == 2 {
+				return "", "", fmt.Errorf("invalid module line: %s", modFileLine)
+			}
+
+			moduleName := sections[1]
+			modulePath = strings.TrimPrefix(absoluteModulePath, rootDir)
+
+			return moduleName, modulePath, nil
+
 		}
 	}
 

--- a/pkg/executors/golang/codegen/patch_workspace.go
+++ b/pkg/executors/golang/codegen/patch_workspace.go
@@ -1,0 +1,110 @@
+package codegen
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+)
+
+type workspaceFinder struct {
+	rootDir string
+}
+
+func newWorkspaceFinder(rootDir string) *workspaceFinder {
+	return &workspaceFinder{
+		rootDir: rootDir,
+	}
+}
+
+func (w *workspaceFinder) rootWorkspaceExists() bool {
+	goWork := path.Join(w.rootDir, "go.work")
+	if _, err := os.Stat(goWork); errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+
+	return true
+}
+
+func (s *workspaceFinder) Find(ctx context.Context) (packages map[string]string, ok bool, err error) {
+	if !s.rootWorkspaceExists() {
+		return nil, false, nil
+	}
+
+	modules, err := s.getWorkspaceModules()
+	if err != nil {
+		return nil, true, err
+	}
+
+	packages = make(map[string]string, 0)
+	for _, module := range modules {
+		moduleName, modulePath, err := s.getWorkspaceModule(module)
+		if err != nil {
+			return nil, true, err
+		}
+		packages[moduleName] = modulePath
+	}
+
+	return packages, true, nil
+}
+
+func (w *workspaceFinder) getWorkspaceModules() (modules []string, err error) {
+	workFile, err := os.ReadFile(path.Join(w.rootDir, "go.work"))
+	if err != nil {
+		return nil, err
+	}
+
+	workFileContent := string(workFile)
+	lines := strings.Split(workFileContent, "\n")
+	if len(lines) == 0 {
+		return nil, errors.New("go work is empty")
+	}
+
+	modules = make([]string, 0)
+	for _, line := range lines {
+		modFileLine := strings.Trim(strings.TrimSpace(line), "\t")
+		if strings.HasPrefix(modFileLine, ".") && modFileLine != "./actions" {
+			modules = append(
+				modules,
+				strings.TrimPrefix(
+					strings.TrimPrefix(modFileLine, "."),
+					"/",
+				),
+			)
+		}
+	}
+
+	return modules, nil
+}
+
+func (w *workspaceFinder) getWorkspaceModule(absoluteModulePath string) (moduleName string, modulePath string, err error) {
+	modFile, err := os.ReadFile(path.Join(w.rootDir, absoluteModulePath, "go.mod"))
+	if err != nil {
+		return "", "", fmt.Errorf("failed to find go.mod at: %s: %w", absoluteModulePath, err)
+	}
+
+	modFileContent := string(modFile)
+	lines := strings.Split(modFileContent, "\n")
+	if len(lines) == 0 {
+		return "", "", errors.New("go mod is empty")
+	}
+
+	for _, line := range lines {
+		modFileLine := strings.TrimSpace(line)
+		if strings.HasPrefix(modFileLine, "module") {
+			sections := strings.Split(modFileLine, " ")
+			if len(sections) < 2 {
+				return "", "", fmt.Errorf("invalid module line: %s", modFileLine)
+			}
+
+			moduleName := sections[1]
+			modulePath = strings.TrimPrefix(absoluteModulePath, w.rootDir)
+
+			return moduleName, modulePath, nil
+		}
+	}
+
+	return "", "", errors.New("failed to find a valid go.mod file")
+}

--- a/pkg/executors/golang/codegen/testdata/patch/replace_existing/.shuttle/actions/tmp/go.mod
+++ b/pkg/executors/golang/codegen/testdata/patch/replace_existing/.shuttle/actions/tmp/go.mod
@@ -1,0 +1,9 @@
+module actions
+
+require (
+	replace_existing v0.0.0
+)
+
+go 1.21.4
+
+replace replace_existing => ../bogus

--- a/pkg/executors/golang/codegen/testdata/patch/replace_existing/go.mod
+++ b/pkg/executors/golang/codegen/testdata/patch/replace_existing/go.mod
@@ -1,0 +1,3 @@
+module replace_existing
+
+go 1.21.4

--- a/pkg/executors/golang/codegen/testdata/patch/root_module/.shuttle/actions/tmp/go.mod
+++ b/pkg/executors/golang/codegen/testdata/patch/root_module/.shuttle/actions/tmp/go.mod
@@ -1,0 +1,7 @@
+module actions
+
+require (
+	root_module
+)
+
+go 1.21.4

--- a/pkg/executors/golang/codegen/testdata/patch/root_module/go.mod
+++ b/pkg/executors/golang/codegen/testdata/patch/root_module/go.mod
@@ -1,0 +1,3 @@
+module root_module
+
+go 1.21.4

--- a/pkg/executors/golang/codegen/testdata/patch/root_workspace/.shuttle/actions/tmp/go.mod
+++ b/pkg/executors/golang/codegen/testdata/patch/root_workspace/.shuttle/actions/tmp/go.mod
@@ -1,0 +1,9 @@
+module actions
+
+require (
+	root_workspace v0.0.0
+	subpackage v0.0.0
+	othersubpackage v0.0.0
+)
+
+go 1.21.4

--- a/pkg/executors/golang/codegen/testdata/patch/root_workspace/go.mod
+++ b/pkg/executors/golang/codegen/testdata/patch/root_workspace/go.mod
@@ -1,0 +1,3 @@
+module root_workspace
+
+go 1.21.4

--- a/pkg/executors/golang/codegen/testdata/patch/root_workspace/go.work
+++ b/pkg/executors/golang/codegen/testdata/patch/root_workspace/go.work
@@ -1,0 +1,8 @@
+go 1.21.4
+
+use (
+	.
+	./subpackage
+	./other/subpackage
+	ignored
+)

--- a/pkg/executors/golang/codegen/testdata/patch/root_workspace/other/subpackage/go.mod
+++ b/pkg/executors/golang/codegen/testdata/patch/root_workspace/other/subpackage/go.mod
@@ -1,0 +1,3 @@
+module othersubpackage
+
+go 1.21.4

--- a/pkg/executors/golang/codegen/testdata/patch/root_workspace/subpackage/go.mod
+++ b/pkg/executors/golang/codegen/testdata/patch/root_workspace/subpackage/go.mod
@@ -1,0 +1,3 @@
+module subpackage
+
+go 1.21.4

--- a/pkg/executors/golang/compile/compile.go
+++ b/pkg/executors/golang/compile/compile.go
@@ -117,7 +117,7 @@ func compile(ctx context.Context, ui *ui.UI, actions *discover.ActionsDiscovered
 
 	var binarypath string
 
-	if err := codegen.PatchGoMod(actions.ParentDir, shuttlelocaldir, ui); err != nil {
+	if err := codegen.NewPatcher().Patch(ctx, actions.ParentDir, shuttlelocaldir); err != nil {
 		return "", fmt.Errorf("failed to patch generated go.mod: %w", err)
 	}
 

--- a/pkg/executors/golang/compile/compile.go
+++ b/pkg/executors/golang/compile/compile.go
@@ -48,6 +48,8 @@ func Compile(ctx context.Context, ui *ui.UI, discovered *discover.Discovered) (*
 	binaries := &Binaries{}
 	if discovered.Local != nil {
 		egrp.Go(func() error {
+			ui.Verboseln("compiling golang actions binary for: %s", discovered.Local.DirPath)
+
 			path, err := compile(ctx, ui, discovered.Local)
 			if err != nil {
 				return err
@@ -59,6 +61,8 @@ func Compile(ctx context.Context, ui *ui.UI, discovered *discover.Discovered) (*
 	}
 	if discovered.Plan != nil {
 		egrp.Go(func() error {
+			ui.Verboseln("compiling golang actions binary for: %s", discovered.Plan.DirPath)
+
 			path, err := compile(ctx, ui, discovered.Plan)
 			if err != nil {
 				return err
@@ -113,7 +117,7 @@ func compile(ctx context.Context, ui *ui.UI, actions *discover.ActionsDiscovered
 
 	var binarypath string
 
-	if err := codegen.PatchGoMod(actions.ParentDir, shuttlelocaldir); err != nil {
+	if err := codegen.PatchGoMod(actions.ParentDir, shuttlelocaldir, ui); err != nil {
 		return "", fmt.Errorf("failed to patch generated go.mod: %w", err)
 	}
 

--- a/pkg/executors/golang/compile/compile.go
+++ b/pkg/executors/golang/compile/compile.go
@@ -113,14 +113,19 @@ func compile(ctx context.Context, ui *ui.UI, actions *discover.ActionsDiscovered
 
 	var binarypath string
 
+	if err := codegen.PatchGoMod(actions.ParentDir, shuttlelocaldir); err != nil {
+		return "", fmt.Errorf("failed to patch generated go.mod: %w", err)
+	}
+
 	if goInstalled() {
+		if err = codegen.ModTidy(ctx, ui, shuttlelocaldir); err != nil {
+			return "", fmt.Errorf("go mod tidy failed: %w", err)
+		}
+
 		if err = codegen.Format(ctx, ui, shuttlelocaldir); err != nil {
 			return "", fmt.Errorf("go fmt failed: %w", err)
 		}
 
-		if err = codegen.ModTidy(ctx, ui, shuttlelocaldir); err != nil {
-			return "", fmt.Errorf("go mod tidy failed: %w", err)
-		}
 		binarypath, err = codegen.CompileBinary(ctx, ui, shuttlelocaldir)
 		if err != nil {
 			return "", fmt.Errorf("go build failed: %w", err)

--- a/pkg/executors/golang/compile/matcher/matcher.go
+++ b/pkg/executors/golang/compile/matcher/matcher.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/lunarway/shuttle/pkg/executors/golang/discover"
 	"github.com/lunarway/shuttle/pkg/ui"
+	"golang.org/x/exp/slices"
 	"golang.org/x/mod/sumdb/dirhash"
 )
 
@@ -66,6 +67,7 @@ func GetHash(ctx context.Context, actions *discover.ActionsDiscovered) (string, 
 		return io.NopCloser(bytes.NewReader(b)), nil
 	}
 
+	slices.Sort(entries)
 	hash, err := dirhash.Hash1(entries, open)
 	if err != nil {
 		return "", err

--- a/pkg/executors/golang/executer/prepare.go
+++ b/pkg/executors/golang/executer/prepare.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/lunarway/shuttle/pkg/config"
 	"github.com/lunarway/shuttle/pkg/executors/golang/compile"
@@ -17,6 +18,8 @@ func prepare(
 	path string,
 	c *config.ShuttleProjectContext,
 ) (*compile.Binaries, error) {
+	ui.Verboseln("preparing shuttle golang actions")
+	start := time.Now()
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 
 	disc, err := discover.Discover(ctx, path, c)
@@ -28,6 +31,9 @@ func prepare(
 	if err != nil {
 		return nil, fmt.Errorf("failed to compile binaries: %v", err)
 	}
+
+	elapsed := time.Since(start)
+	ui.Verboseln("preparing shuttle golang actions took: %d ms", elapsed.Milliseconds())
 
 	return binaries, nil
 }

--- a/pkg/executors/golang/executer/run.go
+++ b/pkg/executors/golang/executer/run.go
@@ -20,6 +20,7 @@ func Run(
 		return err
 	}
 
+	ui.Verboseln("executing shuttle golang actions")
 	if err := executeAction(ctx, binaries, args...); err != nil {
 		return err
 	}

--- a/pkg/executors/task.go
+++ b/pkg/executors/task.go
@@ -26,7 +26,7 @@ func executeTask(ctx context.Context, ui *ui.UI, context ActionExecutionContext)
 		args = append(args, value)
 	}
 
-	err := executer.Run(ctx, ui, &context.ScriptContext.Project, "shuttle.yaml", args...)
+	err := executer.Run(ctx, ui, &context.ScriptContext.Project, fmt.Sprintf("%s/shuttle.yaml", context.ScriptContext.Project.ProjectPath), args...)
 	if err != nil {
 		return err
 	}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -164,7 +164,7 @@ func GetGitPlan(
 			panic(fmt.Sprintf("Unknown protocol '%s'", parsedGitPlan.Protocol))
 		}
 
-		uii.Infoln("Cloning plan %s", cloneArg)
+		uii.Errorln("Cloning plan %s", cloneArg)
 		err = gitCmd(fmt.Sprintf("clone %v --branch %v plan", cloneArg, parsedGitPlan.Head), localShuttleDirectoryPath, uii)
 		if err != nil {
 			return "", err

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -164,7 +164,7 @@ func GetGitPlan(
 			panic(fmt.Sprintf("Unknown protocol '%s'", parsedGitPlan.Protocol))
 		}
 
-		uii.Errorln("Cloning plan %s", cloneArg)
+		uii.Infoln("Cloning plan %s", cloneArg)
 		err = gitCmd(fmt.Sprintf("clone %v --branch %v plan", cloneArg, parsedGitPlan.Head), localShuttleDirectoryPath, uii)
 		if err != nil {
 			return "", err

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -21,7 +21,7 @@ func Create(out, err io.Writer) *UI {
 		EffectiveLevel: LevelInfo,
 		DefaultLevel:   LevelInfo,
 		UserLevelSet:   false,
-		Out:            err,
+		Out:            out,
 		Err:            err,
 	}
 }

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -21,7 +21,7 @@ func Create(out, err io.Writer) *UI {
 		EffectiveLevel: LevelInfo,
 		DefaultLevel:   LevelInfo,
 		UserLevelSet:   false,
-		Out:            out,
+		Out:            err,
 		Err:            err,
 	}
 }


### PR DESCRIPTION
This pr adds a few things:

1. Go mod support in the same repository
2. Go workspace support in the same repository

This is because you may want to use the local packages in the repository in case your actions need to depend on your service or library code.

If workspaces exist, we depend on that solely, as that should tell us where all the subpackages are located
Else if a root module exist we add that. As such both are optional.

It should also work under least surprises, that is if it works in ./actions folder, it should work when the final binaries are compiled

Fixes: AURA-1465, AURA-1466