### PR TITLE
feat: with shuttle available outside of a repository

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -160,9 +160,9 @@ func initializedRootFromArgs(stdout, stderr io.Writer, args []string) (*cobra.Co
 	rootCmd.ParseFlags(args)
 
 	if isInRepoContext() {
-		runCmd, initErr := newRun(uii, ctxProvider)
-		if initErr != nil {
-			return nil, nil, initErr
+		runCmd, err := newRun(uii, ctxProvider)
+		if err != nil {
+			return nil, nil, err
 		}
 		rootCmd.AddCommand(
 			newDocumentation(uii, ctxProvider),
@@ -183,9 +183,12 @@ func initializedRootFromArgs(stdout, stderr io.Writer, args []string) (*cobra.Co
 		return rootCmd, uii, nil
 	} else {
 		rootCmd.AddCommand(
+			newNoContextRun(),
 			newCompletion(uii),
 			newVersion(uii),
 			newTelemetry(uii),
+			newHas(uii, ctxProvider),
+			newConfig(uii, ctxProvider),
 		)
 
 		return rootCmd, uii, nil
@@ -299,5 +302,5 @@ func getRepositoryContext(projectPath string) bool {
 		}
 	}
 
-	return false
+	return true
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -17,6 +17,25 @@ import (
 	"github.com/lunarway/shuttle/pkg/ui"
 )
 
+func newNoopRun() *cobra.Command {
+	return &cobra.Command{
+		Use:          "run [command]",
+		Short:        "Run a plan script",
+		Long:         `Specify which plan script to run`,
+		SilenceUsage: true,
+	}
+}
+
+func newNoContextRun() *cobra.Command {
+	runCmd := newNoopRun()
+
+	runCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return fmt.Errorf("shuttle run is not available in this context. To use shuttle run you need to be in a project with a shuttle.yaml file")
+	}
+
+	return runCmd
+}
+
 func newRun(uii *ui.UI, contextProvider contextProvider) (*cobra.Command, error) {
 	var (
 		flagTemplate   string
@@ -31,12 +50,7 @@ func newRun(uii *ui.UI, contextProvider contextProvider) (*cobra.Command, error)
 
 	executorRegistry := executors.NewRegistry(executors.ShellExecutor, executors.TaskExecutor)
 
-	runCmd := &cobra.Command{
-		Use:          "run [command]",
-		Short:        "Run a plan script",
-		Long:         `Specify which plan script to run`,
-		SilenceUsage: true,
-	}
+	runCmd := newNoopRun()
 
 	context, err := contextProvider()
 	if err != nil {

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -99,14 +99,9 @@ Global Flags:
 			name:      "project without shuttle.yaml",
 			input:     args("-p", "testdata/base", "run", "hello_stdout"),
 			stdoutput: "",
-			erroutput: `Error: exit code 2 - Failed to load shuttle configuration: shuttle.yaml file not found
-
-Make sure you are in a project using shuttle and that a 'shuttle.yaml' file is available.
-`,
-			initErr: errors.New(
-				`exit code 2 - Failed to load shuttle configuration: shuttle.yaml file not found
-
-Make sure you are in a project using shuttle and that a 'shuttle.yaml' file is available.`,
+			erroutput: "Error: shuttle run is not available in this context. To use shuttle run you need to be in a project with a shuttle.yaml file\n",
+			err: errors.New(
+				"shuttle run is not available in this context. To use shuttle run you need to be in a project with a shuttle.yaml file",
 			),
 		},
 		{


### PR DESCRIPTION
This makes sure that we don't error hard when not in a repository context.

This will also print to stderr, to let the user know that shuttle was run outside of what it expects

Fixes: AURA-1517
