### PR TITLE
feat: with override for golang actions

### DIFF
--- a/pkg/executors/golang/compile/compile.go
+++ b/pkg/executors/golang/compile/compile.go
@@ -175,7 +175,7 @@ func compileWithDagger(ctx context.Context, ui *ui.UI, shuttlelocaldir string) (
 	log.Printf("nakedShuttleDir: %s", nakedShuttleDir)
 
 	shuttleBinary := client.Container().
-		From("golang:1.20-alpine").
+		From(getGolangImage()).
 		WithWorkdir("/app").
 		WithDirectory(".", src).
 		WithWorkdir(path.Join(nakedShuttleDir, "tmp")).
@@ -219,4 +219,19 @@ func goInstalled() bool {
 	}
 
 	return true
+}
+
+func getGolangImage() string {
+	const (
+		// renovate: datasource=docker depName=golang
+		golangImageVersion = "1.20-alpine"
+	)
+
+	golangImage := fmt.Sprintf("golang:%s", golangImageVersion)
+	golangImageOverride := os.Getenv("SHUTTLE_GOLANG_IMAGE")
+	if golangImageOverride != "" {
+		return golangImageOverride
+	}
+
+	return golangImage
 }

--- a/pkg/executors/golang/executer/list.go
+++ b/pkg/executors/golang/executer/list.go
@@ -2,6 +2,7 @@ package executer
 
 import (
 	"context"
+	"os"
 
 	"github.com/lunarway/shuttle/pkg/config"
 	"github.com/lunarway/shuttle/pkg/ui"
@@ -13,6 +14,11 @@ func List(
 	path string,
 	c *config.ShuttleProjectContext,
 ) (*Actions, error) {
+	if !isActionsEnabled() {
+		ui.Verboseln("shuttle golang actions disabled")
+		return NewActions(), nil
+	}
+
 	binaries, err := prepare(ctx, ui, path, c)
 	if err != nil {
 		return nil, err
@@ -32,4 +38,14 @@ func List(
 		Merge(planInquire)
 
 	return actions, nil
+}
+
+func isActionsEnabled() bool {
+	enabled := os.Getenv("SHUTTLE_GOLANG_ACTIONS")
+
+	if enabled == "false" {
+		return false
+	}
+
+	return true
 }

--- a/pkg/executors/golang/executer/run.go
+++ b/pkg/executors/golang/executer/run.go
@@ -14,6 +14,11 @@ func Run(
 	path string,
 	args ...string,
 ) error {
+	if !isActionsEnabled() {
+		ui.Verboseln("shuttle golang actions disabled")
+		return nil
+	}
+
 	binaries, err := prepare(ctx, ui, path, c)
 	if err != nil {
 		ui.Errorln("failed to run command: %v", err)

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,28 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>lunarway/renovate-config"
+  ],
+  "regexManagers": [
+    {
+      "description": "Update docker images in go files",
+      "fileMatch": [
+        "^.*\\.go$"
+      ],
+      "matchStrings": [
+        "\\/\\/ renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>[a-z-]+)\\s+([a-zA-Z]*)\\s*[:|=]\\s+\"(?<currentValue>.*)\"\\,?"
+      ],
+      "versioningTemplate": "docker"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Update docker tags frequently",
+      "matchDatasources": [
+        "docker"
+      ],
+      "extends": [
+        "schedule:nonOfficeHours"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
This adds a few features for keeping the fallback dagger build pipeline up to date, as well as allowing a complete disabling of golang actions
