### PR TITLE
fix shuttle should search recursively for shuttle files

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShuttleFileExists(t *testing.T) {
+	t.Parallel()
+
+	t.Run("full path, with file", func(t *testing.T) {
+		actual := shuttleFileExists("/some/long/path", func(filePath string) bool {
+			switch filePath {
+			case "/some/long/path/shuttle.yaml":
+				return true
+			default:
+				pathNotExpected(t, filePath)
+				return false
+			}
+		})
+
+		assert.True(t, actual)
+	})
+
+	t.Run("full path, no file", func(t *testing.T) {
+		actual := shuttleFileExists("/some/long/path", func(filePath string) bool {
+			switch filePath {
+			case "/some/long/path/shuttle.yaml":
+				return false
+			default:
+				pathNotExpected(t, filePath)
+				return true
+			}
+		})
+
+		assert.False(t, actual)
+	})
+
+	t.Run("current path, with file", func(t *testing.T) {
+		actual := shuttleFileExists(".", func(filePath string) bool {
+			switch filePath {
+			case "shuttle.yaml":
+				return true
+			default:
+				pathNotExpected(t, filePath)
+				return false
+			}
+		})
+
+		assert.True(t, actual)
+	})
+
+	t.Run("current path, no file", func(t *testing.T) {
+		actual := shuttleFileExists(".", func(filePath string) bool {
+			switch filePath {
+			case "shuttle.yaml":
+				return false
+			default:
+				pathNotExpected(t, filePath)
+				return true
+			}
+		})
+
+		assert.False(t, actual)
+	})
+}
+
+func TestShuttleFileExistsRecursive(t *testing.T) {
+	t.Parallel()
+
+	t.Run("full path, file in given path", func(t *testing.T) {
+		actual := shuttleFileExistsRecursive("/some/long/path", func(filePath string) bool {
+			switch filePath {
+			case "/some/long/path/shuttle.yaml":
+				return true
+			default:
+				pathNotExpected(t, filePath)
+				return false
+			}
+		})
+
+		assert.True(t, actual)
+	})
+
+	t.Run("full path, file in sub directory", func(t *testing.T) {
+		actual := shuttleFileExistsRecursive("/some/long/path", func(filePath string) bool {
+			switch filePath {
+			case "/some/long/path/shuttle.yaml":
+				return false
+			case "/some/long/shuttle.yaml":
+				return true
+			default:
+				pathNotExpected(t, filePath)
+				return false
+			}
+		})
+
+		assert.True(t, actual)
+	})
+
+	t.Run("full path, file in root", func(t *testing.T) {
+		actual := shuttleFileExistsRecursive("/some/long/path", func(filePath string) bool {
+			switch filePath {
+			case "/some/long/path/shuttle.yaml":
+				return false
+			case "/some/long/shuttle.yaml":
+				return false
+			case "/some/shuttle.yaml":
+				return false
+			case "/shuttle.yaml":
+				return true
+			default:
+				pathNotExpected(t, filePath)
+				return false
+			}
+		})
+
+		assert.True(t, actual)
+	})
+
+	t.Run("empty path, file false", func(t *testing.T) {
+		actual := shuttleFileExistsRecursive("", func(filePath string) bool {
+			switch filePath {
+			case "shuttle.yaml":
+				return false
+			default:
+				pathNotExpected(t, filePath)
+				return false
+			}
+		})
+
+		assert.False(t, actual)
+	})
+
+	t.Run("current dir, file found", func(t *testing.T) {
+		actual := shuttleFileExistsRecursive(".", func(filePath string) bool {
+			switch filePath {
+			case "shuttle.yaml":
+				return true
+			default:
+				pathNotExpected(t, filePath)
+				return false
+			}
+		})
+
+		assert.True(t, actual)
+	})
+}
+
+func pathNotExpected(t *testing.T, filePath string) {
+	t.Helper()
+
+	assert.Fail(t, "path was not expected", "the path %s was not expected in matcher", filePath)
+}


### PR DESCRIPTION
The reason is that all the other commands support it, so we should register the commands if a shuttle file is available.

The change was made to search recursively until the path is empty. If a given path --project or -p is supplied, we won't do recursive checks.