### PR TITLE
fix: shuttle should resolve file not found in root

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -305,8 +305,12 @@ func shuttleFileExistsRecursive(projectPath string, existsFunc fileExistsFunc) b
 			return true
 		}
 
-		return shuttleFileExistsRecursive(path.Dir(projectPath), existsFunc)
+		parentProjectDir := path.Dir(projectPath)
+		if parentProjectDir == projectPath {
+			return false
+		}
 
+		return shuttleFileExistsRecursive(parentProjectDir, existsFunc)
 	}
 
 	return shuttleFileExists(projectPath, existsFunc)

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -119,6 +119,28 @@ func TestShuttleFileExistsRecursive(t *testing.T) {
 		assert.True(t, actual)
 	})
 
+	t.Run("full path, file not found", func(t *testing.T) {
+		actual := shuttleFileExistsRecursive("/some/long/path", func(filePath string) bool {
+			switch filePath {
+			case "/some/long/path/shuttle.yaml":
+				return false
+			case "/some/long/shuttle.yaml":
+				return false
+			case "/some/shuttle.yaml":
+				return false
+			case "/shuttle.yaml":
+				return false
+			case "/":
+				return false
+			default:
+				pathNotExpected(t, filePath)
+				return true
+			}
+		})
+
+		assert.False(t, actual)
+	})
+
 	t.Run("empty path, file false", func(t *testing.T) {
 		actual := shuttleFileExistsRecursive("", func(filePath string) bool {
 			switch filePath {


### PR DESCRIPTION
I'd missed a base case, because path.Dir should return an empty string for "/", it however returned "/", resulting in an endless recursive loop

This was fixed by comparing the projectPath to the new pathDir, if they are the same we terminate the recursive loop
