### PR TITLE
Sonoma broke grep

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,16 @@ chmod +x shuttle-darwin-amd64
 sudo mv shuttle-darwin-amd64 /usr/local/bin/shuttle
 ```
 
+#### Mac OS Sonoma (broke grep)
+
+Use ripgrep instead (rg)
+
+```console
+curl -LO https://github.com/lunarway/shuttle/releases/download/$(curl -Lso /dev/null -w %{url_effective} https://github.com/lunarway/shuttle/releases/latest | rg -o '[^/]*$')/shuttle-darwin-amd64
+chmod +x shuttle-darwin-amd64
+sudo mv shuttle-darwin-amd64 /usr/local/bin/shuttle
+```
+
 ### Linux
 
 ```console


### PR DESCRIPTION
Sonoma broke grep for `*` match forward. I couldn't find a good workaround that worked for me. As such lets default to a better grep `ripgrep`.