### PR TITLE
feat: use awk instead of grep

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,11 +8,11 @@ runs:
             mkdir -p ~/bin
             
             if [[ $(uname -m) == 'arm64' ]]; then
-                curl -LO https://github.com/lunarway/shuttle/releases/download/$(curl -Lso /dev/null -w %{url_effective} https://github.com/lunarway/shuttle/releases/latest | grep -o '[^/]*$')/shuttle-darwin-arm64
+                curl -LO https://github.com/lunarway/shuttle/releases/download/$(curl -Lso /dev/null -w %{url_effective} https://github.com/lunarway/shuttle/releases/latest | awk -F'/' '{print $NF}')/shuttle-darwin-arm64
                 chmod +x shuttle-darwin-arm64
                 mv shuttle-darwin-arm64 ~/bin/shuttle
             else
-                curl -LO https://github.com/lunarway/shuttle/releases/download/$(curl -Lso /dev/null -w %{url_effective} https://github.com/lunarway/shuttle/releases/latest | grep -o '[^/]*$')/shuttle-darwin-amd64
+                curl -LO https://github.com/lunarway/shuttle/releases/download/$(curl -Lso /dev/null -w %{url_effective} https://github.com/lunarway/shuttle/releases/latest | awk -F'/' '{print $NF}')/shuttle-darwin-amd64
                 chmod +x shuttle-darwin-amd64
                 mv shuttle-darwin-amd64 ~/bin/shuttle
             fi


### PR DESCRIPTION
Grep is broken on macos sonoma. Instead we can use `awk`
