### PR TITLE
feat(extensions): add install extensions from registry

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -160,6 +160,9 @@ func initializedRootFromArgs(stdout, stderr io.Writer, args []string) (*cobra.Co
 	rootCmd.ParseFlags(args)
 
 	rootCmd.AddCommand(newExtCmd())
+	if err := addExtensions(rootCmd); err != nil {
+		uii.Verboseln("failed to register extensions: %s", err.Error())
+	}
 
 	if isInRepoContext() {
 		runCmd, err := newRun(uii, ctxProvider)

--- a/internal/extensions/downloader.go
+++ b/internal/extensions/downloader.go
@@ -1,0 +1,75 @@
+package extensions
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+type Downloader interface {
+	Download(ctx context.Context, dest string) error
+}
+
+func NewDownloader(downloadLink *registryExtensionDownloadLink) (Downloader, error) {
+	switch downloadLink.Provider {
+	case "github-release":
+		return newGitHubReleaseDownloader(downloadLink), nil
+	default:
+		return nil, fmt.Errorf("invalid provider type: %s", downloadLink.Provider)
+	}
+}
+
+type gitHubReleaseDownloader struct {
+	link *registryExtensionDownloadLink
+}
+
+func newGitHubReleaseDownloader(downloadLink *registryExtensionDownloadLink) Downloader {
+	return &gitHubReleaseDownloader{
+		link: downloadLink,
+	}
+}
+
+func (d *gitHubReleaseDownloader) Download(ctx context.Context, dest string) error {
+	client := http.DefaultClient
+	client.Timeout = time.Second * 60
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, d.link.Url, nil)
+	if err != nil {
+		return err
+	}
+
+	bearer, err := getGithubToken()
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("Authorization", fmt.Sprintf("token %s", bearer))
+	req.Header.Add("Accept", "application/octet-stream")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if err := os.RemoveAll(dest); err != nil {
+		log.Printf("failed to remove extension before downloading new: %s, please try again", err.Error())
+	}
+
+	extensionBinary, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer extensionBinary.Close()
+	extensionBinary.Chmod(0o755)
+
+	if _, err := io.Copy(extensionBinary, resp.Body); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/extensions/extension.go
+++ b/internal/extensions/extension.go
@@ -35,7 +35,8 @@ func (e *Extension) Ensure(ctx context.Context) error {
 
 	binaryPath := path.Join(extensionsCachePath, binaryName)
 	if exists(binaryPath) {
-		return nil
+		// TODO: do a checksum chck
+		//return nil
 	}
 
 	downloadLink := e.getRemoteBinaryDownloadLink()
@@ -43,13 +44,36 @@ func (e *Extension) Ensure(ctx context.Context) error {
 		return fmt.Errorf("failed to find a valid extension matching your os and architecture")
 	}
 
-	//TODO: Initiate download
+	downloader, err := NewDownloader(downloadLink)
+	if err != nil {
+		return err
+	}
 
-	panic("not implemented yet")
+	if err := downloader.Download(ctx, binaryPath); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *Extension) Name() string {
+	return e.remote.Name
+}
+
+func (e *Extension) Version() string {
+	return e.remote.Version
+}
+
+func (e *Extension) Description() string {
+	return e.remote.Description
 }
 
 func (e *Extension) getExtensionBinaryName() string {
 	return e.remote.Name
+}
+
+func (e *Extension) FullPath() string {
+	return path.Join(getExtensionsCachePath(e.globalStore), e.Name())
 }
 
 func (e *Extension) getRemoteBinaryDownloadLink() *registryExtensionDownloadLink {

--- a/internal/extensions/extension.go
+++ b/internal/extensions/extension.go
@@ -18,16 +18,12 @@ type Extension struct {
 }
 
 func newExtensionFromRegistry(globalStore *global.GlobalStore, registryExtension *registryExtension) (*Extension, error) {
-	os := runtime.GOOS
-	arch := runtime.GOARCH
-
 	return &Extension{
-		os:          os,
-		arch:        arch,
+		os:          runtime.GOOS,
+		arch:        runtime.GOARCH,
 		globalStore: globalStore,
 		remote:      registryExtension,
 	}, nil
-
 }
 
 func (e *Extension) Ensure(ctx context.Context) error {

--- a/internal/extensions/extension.go
+++ b/internal/extensions/extension.go
@@ -1,4 +1,68 @@
 package extensions
 
+import (
+	"context"
+	"fmt"
+	"path"
+	"runtime"
+
+	"github.com/lunarway/shuttle/internal/global"
+)
+
 // Extension is the descriptor of a single extension, it is used to add description to the cli, as well as calling the specific extension in question
-type Extension struct{}
+type Extension struct {
+	os          string
+	arch        string
+	globalStore *global.GlobalStore
+	remote      *registryExtension
+}
+
+func newExtensionFromRegistry(globalStore *global.GlobalStore, registryExtension *registryExtension) (*Extension, error) {
+	os := runtime.GOOS
+	arch := runtime.GOARCH
+
+	return &Extension{
+		os:          os,
+		arch:        arch,
+		globalStore: globalStore,
+		remote:      registryExtension,
+	}, nil
+
+}
+
+func (e *Extension) Ensure(ctx context.Context) error {
+	extensionsCachePath := getExtensionsCachePath(e.globalStore)
+	binaryName := e.getExtensionBinaryName()
+	if err := ensureExists(extensionsCachePath); err != nil {
+		return fmt.Errorf("failed to create cache path: %w", err)
+	}
+
+	binaryPath := path.Join(extensionsCachePath, binaryName)
+	if exists(binaryPath) {
+		return nil
+	}
+
+	downloadLink := e.getRemoteBinaryDownloadLink()
+	if downloadLink == nil {
+		return fmt.Errorf("failed to find a valid extension matching your os and architecture")
+	}
+
+	//TODO: Initiate download
+
+	panic("not implemented yet")
+}
+
+func (e *Extension) getExtensionBinaryName() string {
+	return e.remote.Name
+}
+
+func (e *Extension) getRemoteBinaryDownloadLink() *registryExtensionDownloadLink {
+	for _, download := range e.remote.DownloadUrls {
+		if download.Os == e.os &&
+			download.Architecture == e.arch {
+			return &download
+		}
+	}
+
+	return nil
+}

--- a/internal/extensions/extension_source.go
+++ b/internal/extensions/extension_source.go
@@ -1,0 +1,44 @@
+package extensions
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+type shuttleExtensionsRegistry struct {
+	GitHub *string `json:"github" yaml:"github"`
+}
+
+type shuttleExtensionProviderGitHubRelease struct {
+	Owner string `json:"owner" yaml:"owner"`
+	Repo  string `json:"repo" yaml:"repo"`
+}
+
+type shuttleExtensionsProvider struct {
+	GitHubRelease *shuttleExtensionProviderGitHubRelease `json:"github-release" yaml:"github-release"`
+}
+
+type shuttleExtensionsFile struct {
+	Name        string `json:"name" yaml:"name"`
+	Description string `json:"description" yaml:"description"`
+
+	Provider shuttleExtensionsProvider `json:"provider" yaml:"provider"`
+	Registry shuttleExtensionsRegistry `json:"registry" yaml:"registry"`
+}
+
+func getExtensionsFile(_ context.Context) (*shuttleExtensionsFile, error) {
+	templateFileContent, err := os.ReadFile("shuttle.template.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("failed to find shuttle.template.yaml: %w", err)
+	}
+
+	var templateFile shuttleExtensionsFile
+	if err := yaml.Unmarshal(templateFileContent, &templateFile); err != nil {
+		return nil, fmt.Errorf("failed to parse shuttle.template.yaml: %w", err)
+	}
+
+	return &templateFile, nil
+}

--- a/internal/extensions/extensions.go
+++ b/internal/extensions/extensions.go
@@ -25,7 +25,30 @@ func (e *ExtensionsManager) Init(ctx context.Context) error {
 
 // GetAll will return all known and installed extensions
 func (e *ExtensionsManager) GetAll(ctx context.Context) ([]Extension, error) {
-	return nil, nil
+	registry := getRegistryPath(e.globalStore)
+
+	index := newRegistryIndex(registry)
+
+	registryExtensions, err := index.getExtensions(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to install extensions, could not get extensions from index: %w", err)
+	}
+
+	extensions := make([]Extension, 0)
+	for _, registryExtension := range registryExtensions {
+		registryExtension := registryExtension
+
+		extension, err := newExtensionFromRegistry(e.globalStore, &registryExtension)
+		if err != nil {
+			return nil, err
+		}
+
+		if extension != nil {
+			extensions = append(extensions, *extension)
+		}
+	}
+
+	return extensions, nil
 }
 
 // Install will ensure that all known extensions are installed and ready for use
@@ -53,7 +76,7 @@ func (e *ExtensionsManager) Install(ctx context.Context) error {
 
 // Update will fetch the latest extensions from a registry and install them afterwards so that they're ready for use
 func (e *ExtensionsManager) Update(ctx context.Context, registry string) error {
-	reg, err := NewRegistry(registry, e.globalStore)
+	reg, err := NewRegistryFromCombined(registry, e.globalStore)
 	if err != nil {
 		return fmt.Errorf("failed to update extensions: %w", err)
 	}
@@ -63,6 +86,24 @@ func (e *ExtensionsManager) Update(ctx context.Context, registry string) error {
 	}
 
 	if err := e.Install(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *ExtensionsManager) Publish(ctx context.Context, version string) error {
+	extensionsFile, err := getExtensionsFile(ctx)
+	if err != nil {
+		return err
+	}
+
+	registry, err := newGitHubRegistry()
+	if err != nil {
+		return err
+	}
+
+	if err := registry.Publish(ctx, extensionsFile, version); err != nil {
 		return err
 	}
 

--- a/internal/extensions/extensions.go
+++ b/internal/extensions/extensions.go
@@ -30,6 +30,26 @@ func (e *ExtensionsManager) GetAll(ctx context.Context) ([]Extension, error) {
 
 // Install will ensure that all known extensions are installed and ready for use
 func (e *ExtensionsManager) Install(ctx context.Context) error {
+	registry := getRegistryPath(e.globalStore)
+
+	index := newRegistryIndex(registry)
+
+	extensions, err := index.getExtensions(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to install extensions, could not get extensions from index: %w", err)
+	}
+
+	for _, registryExtension := range extensions {
+		extension, err := newExtensionFromRegistry(e.globalStore, &registryExtension)
+		if err != nil {
+			return err
+		}
+
+		if err := extension.Ensure(ctx); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/internal/extensions/extensions.go
+++ b/internal/extensions/extensions.go
@@ -31,9 +31,7 @@ func (e *ExtensionsManager) GetAll(ctx context.Context) ([]Extension, error) {
 // Install will ensure that all known extensions are installed and ready for use
 func (e *ExtensionsManager) Install(ctx context.Context) error {
 	registry := getRegistryPath(e.globalStore)
-
 	index := newRegistryIndex(registry)
-
 	extensions, err := index.getExtensions(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to install extensions, could not get extensions from index: %w", err)

--- a/internal/extensions/git_registry.go
+++ b/internal/extensions/git_registry.go
@@ -16,6 +16,11 @@ type gitRegistry struct {
 	globalStore *global.GlobalStore
 }
 
+// Publish isn't implemented yet for gitRegistry
+func (*gitRegistry) Publish(ctx context.Context, extFile *shuttleExtensionsFile, version string) error {
+	panic("unimplemented")
+}
+
 func (*gitRegistry) Get(ctx context.Context) error {
 	panic("unimplemented")
 }

--- a/internal/extensions/github_registry.go
+++ b/internal/extensions/github_registry.go
@@ -1,0 +1,324 @@
+package extensions
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+)
+
+type gitHubRegistry struct {
+	client *githubClient
+}
+
+func (g *gitHubRegistry) Publish(ctx context.Context, extFile *shuttleExtensionsFile, version string) error {
+	release, err := g.client.GetRelease(ctx, extFile, version)
+	if err != nil {
+		return err
+	}
+
+	sha, err := g.client.GetFileSHA(ctx, extFile)
+	if err != nil {
+		// TODO: Send error as a debug to log file somewhere
+		// Ignore file as it probably means that the file wasn't there
+	}
+
+	if err := g.client.UpsertFile(ctx, extFile, release, version, sha); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Get isn't implemented yet for GitHubRegistry
+func (*gitHubRegistry) Get(ctx context.Context) error {
+	panic("unimplemented")
+}
+
+// Update isn't implemented yet for GitHubRegistry
+func (*gitHubRegistry) Update(ctx context.Context) error {
+	panic("unimplemented")
+}
+
+func newGitHubRegistry() (Registry, error) {
+	client, err := newGitHubClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return &gitHubRegistry{
+		client: client,
+	}, nil
+}
+
+type githubClient struct {
+	accessToken string
+	httpClient  *http.Client
+}
+
+func newGitHubClient() (*githubClient, error) {
+	token, err := getGithubToken()
+	if err != nil {
+		return nil, err
+	}
+
+	return &githubClient{
+		accessToken: token,
+		httpClient:  http.DefaultClient,
+	}, nil
+}
+
+func (gc *githubClient) GetFileSHA(ctx context.Context, shuttleExtensionsFile *shuttleExtensionsFile) (string, error) {
+	owner, repo, ok := strings.Cut(*shuttleExtensionsFile.Registry.GitHub, "/")
+	if !ok {
+		return "", fmt.Errorf("failed to find owner and repo in registry: %s", *shuttleExtensionsFile.Registry.GitHub)
+	}
+
+	extensionsFile, err := githubClientDo[any, githubFileShaResp](
+		ctx,
+		gc,
+		http.MethodGet,
+		fmt.Sprintf(
+			"/repos/%s/%s/contents/%s",
+			owner,
+			repo,
+			getRemoteRegistryExtensionPathFile(shuttleExtensionsFile.Name),
+		),
+		nil,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return extensionsFile.Sha, nil
+}
+
+func (gc *githubClient) UpsertFile(ctx context.Context, shuttleExtensionsFile *shuttleExtensionsFile, releaseInformation *githubReleaseInformation, version string, sha string) error {
+	registryExtensionsReq := registryExtension{
+		Name:         shuttleExtensionsFile.Name,
+		Description:  shuttleExtensionsFile.Description,
+		Version:      version,
+		DownloadUrls: make([]registryExtensionDownloadLink, 0),
+	}
+
+	for _, releaseAsset := range releaseInformation.Assets {
+		arch, os, err := releaseAsset.ParseDownloadLink(shuttleExtensionsFile.Name)
+		if err != nil {
+			log.Printf("file did not match an actual binary: %s, %s", releaseAsset.DownloadUrl, err.Error())
+			continue
+		}
+
+		downloadLink := registryExtensionDownloadLink{
+			Architecture: arch,
+			Os:           os,
+			Url:          releaseAsset.Url,
+			Provider:     "github-release",
+		}
+
+		registryExtensionsReq.DownloadUrls = append(registryExtensionsReq.DownloadUrls, downloadLink)
+	}
+
+	upsertRequest, err := newGitHubUpsertRequest(
+		shuttleExtensionsFile.Name,
+		version,
+		registryExtensionsReq,
+		sha,
+	)
+	if err != nil {
+		return err
+	}
+
+	owner, repo, ok := strings.Cut(*shuttleExtensionsFile.Registry.GitHub, "/")
+	if !ok {
+		return fmt.Errorf("failed to find owner and repo in registry: %s", *shuttleExtensionsFile.Registry.GitHub)
+	}
+
+	_, err = githubClientDo[githubUpsertFileRequest, any](
+		ctx,
+		gc,
+		http.MethodPut,
+		fmt.Sprintf(
+			"/repos/%s/%s/contents/%s",
+			owner,
+			repo,
+			getRemoteRegistryExtensionPathFile(shuttleExtensionsFile.Name),
+		),
+		upsertRequest,
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (gc *githubClient) GetRelease(ctx context.Context, shuttleExtensionsFile *shuttleExtensionsFile, version string) (*githubReleaseInformation, error) {
+	release, err := githubClientDo[any, githubReleaseInformation](
+		ctx,
+		gc,
+		http.MethodGet,
+		fmt.Sprintf(
+			"/repos/%s/%s/releases/tags/%s",
+			shuttleExtensionsFile.Provider.GitHubRelease.Owner,
+			shuttleExtensionsFile.Provider.GitHubRelease.Repo,
+			version,
+		),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(release.Assets) == 0 {
+		return nil, errors.New("found no releases for github release")
+	}
+
+	return release, nil
+}
+
+type githubReleaseAsset struct {
+	DownloadUrl string `json:"browser_download_url"`
+	Url         string `json:"url"`
+}
+
+func (gra *githubReleaseAsset) ParseDownloadLink(name string) (arch string, os string, err error) {
+	components := strings.Split(gra.DownloadUrl, "/")
+	if len(components) < 3 {
+		return "", "", errors.New("failed to find a proper github download link")
+	}
+
+	file := components[len(components)-1]
+
+	rest, ok := strings.CutPrefix(file, name)
+	if !ok {
+		return "", "", errors.New("file link did not contain extension name")
+	}
+	rest = strings.TrimPrefix(rest, "-")
+
+	os, arch, ok = strings.Cut(rest, "-")
+	if !ok {
+		return "", "", errors.New("file did not match os-arch")
+	}
+
+	return arch, os, nil
+}
+
+type githubReleaseInformation struct {
+	Assets []githubReleaseAsset `json:"assets"`
+}
+
+type githubFileShaResp struct {
+	Sha string `json:"sha"`
+}
+
+type githubCommitter struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+type githubUpsertFileRequest struct {
+	Message   string          `json:"message"`
+	Committer githubCommitter `json:"committer"`
+	Content   string          `json:"content"`
+	Sha       *string         `json:"sha"`
+}
+
+func newGitHubUpsertRequest(name string, version string, registryExtensionsReq registryExtension, sha string) (*githubUpsertFileRequest, error) {
+	committerName := os.Getenv("GITHUB_COMMITTER_NAME")
+	if committerName == "" {
+		return nil, errors.New("GITHUB_COMMITTER_NAME was not found")
+	}
+
+	committerEmail := os.Getenv("GITHUB_COMMITTER_EMAIL")
+	if committerEmail == "" {
+		return nil, errors.New("GITHUB_COMMITTER_EMAIL was not found")
+	}
+
+	content, err := json.MarshalIndent(registryExtensionsReq, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+
+	contentB64 := base64.StdEncoding.EncodeToString(content)
+
+	req := &githubUpsertFileRequest{
+		Message: fmt.Sprintf("chore(extensions): updating %s to %s", name, version),
+		Committer: githubCommitter{
+			Name:  committerName,
+			Email: committerEmail,
+		},
+		Content: contentB64,
+	}
+
+	if sha != "" {
+		req.Sha = &sha
+	}
+
+	return req, nil
+}
+
+func githubClientDo[TReq any, TResp any](ctx context.Context, githubClient *githubClient, method string, path string, reqBody *TReq) (*TResp, error) {
+	var bodyReader io.Reader
+	if reqBody != nil {
+		contents, err := json.Marshal(reqBody)
+		if err != nil {
+			return nil, err
+		}
+
+		bodyReader = bytes.NewReader(contents)
+	}
+
+	url := fmt.Sprintf("https://api.github.com/%s", strings.TrimPrefix(path, "/"))
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		method,
+		url,
+		bodyReader,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Accept", "application/vnd.github+json")
+	req.Header.Add("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", githubClient.accessToken))
+
+	resp, err := githubClient.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respContent, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode > 399 {
+		var message githubMessage
+		if err := json.Unmarshal(respContent, &message); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal resp: %w", err)
+		}
+
+		return nil, fmt.Errorf("failed github request with: %s", message.Message)
+	}
+
+	var returnObject TResp
+	if err := json.Unmarshal(respContent, &returnObject); err != nil {
+		return nil, err
+	}
+
+	return &returnObject, nil
+}
+
+type githubMessage struct {
+	Message string `json:"message"`
+}

--- a/internal/extensions/github_token.go
+++ b/internal/extensions/github_token.go
@@ -1,0 +1,42 @@
+package extensions
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func getGithubToken() (string, error) {
+	if accessToken := os.Getenv("SHUTTLE_EXTENSIONS_GITHUB_ACCESS_TOKEN"); accessToken != "" {
+		return accessToken, nil
+	} else if accessToken := os.Getenv("GITHUB_ACCESS_TOKEN"); accessToken != "" {
+		return accessToken, nil
+	} else {
+		accessToken, err := getToken()
+		if err != nil {
+			return "", err
+		}
+
+		return accessToken, nil
+	}
+}
+
+func getToken() (string, error) {
+	tokenRaw, err := exec.Command("gh", "auth", "token").Output()
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return "", errors.New("github-cli (gh) is not installed")
+		}
+
+		return "", err
+	}
+
+	token := string(tokenRaw)
+
+	if token != "" {
+		return strings.TrimSpace(token), nil
+	}
+
+	return "", errors.New("no github token available (please sign in `gh auth login`)")
+}

--- a/internal/extensions/registry.go
+++ b/internal/extensions/registry.go
@@ -12,10 +12,11 @@ import (
 type Registry interface {
 	Get(ctx context.Context) error
 	Update(ctx context.Context) error
+	Publish(ctx context.Context, extFile *shuttleExtensionsFile, version string) error
 }
 
-// NewRegistry is a shim for concrete implementations of the registries, such as gitRegistry
-func NewRegistry(registry string, globalStore *global.GlobalStore) (Registry, error) {
+// NewRegistryFromCombined is a shim for concrete implementations of the registries, such as gitRegistry
+func NewRegistryFromCombined(registry string, globalStore *global.GlobalStore) (Registry, error) {
 	registryType, registryUrl, ok := strings.Cut(registry, "=")
 	if !ok {
 		return nil, fmt.Errorf("registry was not a valid url: %s", registry)

--- a/internal/extensions/registry_index.go
+++ b/internal/extensions/registry_index.go
@@ -35,7 +35,7 @@ func (r *registryIndex) getExtensions(ctx context.Context) ([]registryExtension,
 
 		extensionContent, err := os.ReadFile(extensionPath)
 		if err != nil {
-			log.Printf("failed to get extension: %w, skipping extension", err)
+			log.Printf("failed to get extension: %s, skipping extension", err.Error())
 			continue
 		}
 

--- a/internal/extensions/registry_index.go
+++ b/internal/extensions/registry_index.go
@@ -19,6 +19,7 @@ type (
 		Os           string `json:"os"`
 		Url          string `json:"url"`
 		Checksum     string `json:"checksum"`
+		Provider     string `json:"provider"`
 	}
 
 	registryExtension struct {
@@ -35,7 +36,7 @@ func newRegistryIndex(registryPath string) *registryIndex {
 	}
 }
 
-func (r *registryIndex) getExtensions(ctx context.Context) ([]registryExtension, error) {
+func (r *registryIndex) getExtensions(_ context.Context) ([]registryExtension, error) {
 	contents, err := os.ReadDir(r.getIndexPath())
 	if err != nil {
 		return nil, fmt.Errorf("failed to list index in registry: %s, %w", r.getIndexPath(), err)

--- a/internal/extensions/registry_index.go
+++ b/internal/extensions/registry_index.go
@@ -9,9 +9,25 @@ import (
 	"path"
 )
 
-type registryIndex struct {
-	registryPath string
-}
+type (
+	registryIndex struct {
+		registryPath string
+	}
+
+	registryExtensionDownloadLink struct {
+		Architecture string `json:"architecture"`
+		Os           string `json:"os"`
+		Url          string `json:"url"`
+		Checksum     string `json:"checksum"`
+	}
+
+	registryExtension struct {
+		Name         string                          `json:"name"`
+		Description  string                          `json:"description"`
+		Version      string                          `json:"version"`
+		DownloadUrls []registryExtensionDownloadLink `json:"downloadUrls"`
+	}
+)
 
 func newRegistryIndex(registryPath string) *registryIndex {
 	return &registryIndex{
@@ -35,7 +51,7 @@ func (r *registryIndex) getExtensions(ctx context.Context) ([]registryExtension,
 
 		extensionContent, err := os.ReadFile(extensionPath)
 		if err != nil {
-			log.Printf("failed to get extension: %s, skipping extension", err.Error())
+			log.Printf("failed to get extension: %s, skipping extension, the extension might be invalid at: %s, please contact your admin", err.Error(), extensionPath)
 			continue
 		}
 
@@ -52,18 +68,4 @@ func (r *registryIndex) getExtensions(ctx context.Context) ([]registryExtension,
 
 func (r *registryIndex) getIndexPath() string {
 	return path.Join(r.registryPath, "index")
-}
-
-type registryExtensionDownloadLink struct {
-	Architecture string `json:"architecture"`
-	Os           string `json:"os"`
-	Url          string `json:"url"`
-	Checksum     string `json:"checksum"`
-}
-
-type registryExtension struct {
-	Name         string                          `json:"name"`
-	Description  string                          `json:"description"`
-	Version      string                          `json:"version"`
-	DownloadUrls []registryExtensionDownloadLink `json:"downloadUrls"`
 }

--- a/internal/extensions/registry_index.go
+++ b/internal/extensions/registry_index.go
@@ -1,0 +1,69 @@
+package extensions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path"
+)
+
+type registryIndex struct {
+	registryPath string
+}
+
+func newRegistryIndex(registryPath string) *registryIndex {
+	return &registryIndex{
+		registryPath: registryPath,
+	}
+}
+
+func (r *registryIndex) getExtensions(ctx context.Context) ([]registryExtension, error) {
+	contents, err := os.ReadDir(r.getIndexPath())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list index in registry: %s, %w", r.getIndexPath(), err)
+	}
+
+	extensions := make([]registryExtension, 0)
+	for _, dir := range contents {
+		if !dir.IsDir() {
+			continue
+		}
+
+		extensionPath := path.Join(r.getIndexPath(), dir.Name(), "shuttle-extension.json")
+
+		extensionContent, err := os.ReadFile(extensionPath)
+		if err != nil {
+			log.Printf("failed to get extension: %w, skipping extension", err)
+			continue
+		}
+
+		var extension registryExtension
+		if err := json.Unmarshal(extensionContent, &extension); err != nil {
+			return nil, fmt.Errorf("failed unmarshal extension at path: %s, err: %w", extensionPath, err)
+		}
+
+		extensions = append(extensions, extension)
+	}
+
+	return extensions, nil
+}
+
+func (r *registryIndex) getIndexPath() string {
+	return path.Join(r.registryPath, "index")
+}
+
+type registryExtensionDownloadLink struct {
+	Architecture string `json:"architecture"`
+	Os           string `json:"os"`
+	Url          string `json:"url"`
+	Checksum     string `json:"checksum"`
+}
+
+type registryExtension struct {
+	Name         string                          `json:"name"`
+	Description  string                          `json:"description"`
+	Version      string                          `json:"version"`
+	DownloadUrls []registryExtensionDownloadLink `json:"downloadUrls"`
+}

--- a/internal/extensions/remote_registry.go
+++ b/internal/extensions/remote_registry.go
@@ -1,0 +1,9 @@
+package extensions
+
+import "context"
+
+type RemoteRegistry interface {
+	Publish(ctx context.Context) error
+}
+
+func NewRemoteRegistry(registry string) {}

--- a/internal/extensions/remote_registry_paths.go
+++ b/internal/extensions/remote_registry_paths.go
@@ -1,0 +1,15 @@
+package extensions
+
+import "path"
+
+func getRemoteRegistryIndex() string {
+	return "index"
+}
+
+func getRemoteRegistryExtensionPath(name string) string {
+	return path.Join(getRemoteRegistryIndex(), name)
+}
+
+func getRemoteRegistryExtensionPathFile(name string) string {
+	return path.Join(getRemoteRegistryExtensionPath(name), "shuttle-extension.json")
+}


### PR DESCRIPTION
This pr includes everything up to actually downloading the extension from the upstream registry

Such as pulling an example registry entry

```json
{
  "name": "SuperExtender",
  "description": "Enhances your experience with superpowers.",
  "version": "1.0.3",
  "downloadUrls": [
    {
      "architecture": "amd64",
      "os": "linux",
      "url": "https://example.com/linux/amd64/superextender.tar.gz",
      "checksum": "efgh5678"
    },
    {
      "architecture": "x86",
      "os": "windows",
      "url": "https://example.com/windows/x86/superextender.zip",
      "checksum": "ijkl91011"
    },
    {
      "architecture": "arm64",
      "os": "darwin",
      "url": "https://example.com/windows/x86/superextender.zip",
      "checksum": "ijkl91011"
    }
  ]
}
```

Which will match on the current os using $GOOS and $GOARCH set by golang itself. We may however have to depend on some other variables if go is not installed by I believe it should work anyway"

Builds on: #222 
