### PR TITLE
feat(extensions): add github release downloader

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -160,6 +160,9 @@ func initializedRootFromArgs(stdout, stderr io.Writer, args []string) (*cobra.Co
 	rootCmd.ParseFlags(args)
 
 	rootCmd.AddCommand(newExtCmd())
+	if err := addExtensions(rootCmd); err != nil {
+		uii.Verboseln("failed to register extensions: %s", err.Error())
+	}
 
 	if isInRepoContext() {
 		runCmd, err := newRun(uii, ctxProvider)

--- a/internal/extensions/extension.go
+++ b/internal/extensions/extension.go
@@ -35,7 +35,8 @@ func (e *Extension) Ensure(ctx context.Context) error {
 
 	binaryPath := path.Join(extensionsCachePath, binaryName)
 	if exists(binaryPath) {
-		return nil
+		// TODO: do a checksum chck
+		//return nil
 	}
 
 	downloadLink := e.getRemoteBinaryDownloadLink()
@@ -55,8 +56,24 @@ func (e *Extension) Ensure(ctx context.Context) error {
 	return nil
 }
 
+func (e *Extension) Name() string {
+	return e.remote.Name
+}
+
+func (e *Extension) Version() string {
+	return e.remote.Version
+}
+
+func (e *Extension) Description() string {
+	return e.remote.Description
+}
+
 func (e *Extension) getExtensionBinaryName() string {
 	return e.remote.Name
+}
+
+func (e *Extension) FullPath() string {
+	return path.Join(getExtensionsCachePath(e.globalStore), e.Name())
 }
 
 func (e *Extension) getRemoteBinaryDownloadLink() *registryExtensionDownloadLink {

--- a/internal/extensions/extension_source.go
+++ b/internal/extensions/extension_source.go
@@ -1,0 +1,44 @@
+package extensions
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+type shuttleExtensionsRegistry struct {
+	GitHub *string `json:"github" yaml:"github"`
+}
+
+type shuttleExtensionProviderGitHubRelease struct {
+	Owner string `json:"owner" yaml:"owner"`
+	Repo  string `json:"repo" yaml:"repo"`
+}
+
+type shuttleExtensionsProvider struct {
+	GitHubRelease *shuttleExtensionProviderGitHubRelease `json:"github-release" yaml:"github-release"`
+}
+
+type shuttleExtensionsFile struct {
+	Name        string `json:"name" yaml:"name"`
+	Description string `json:"description" yaml:"description"`
+
+	Provider shuttleExtensionsProvider `json:"provider" yaml:"provider"`
+	Registry shuttleExtensionsRegistry `json:"registry" yaml:"registry"`
+}
+
+func getExtensionsFile(_ context.Context) (*shuttleExtensionsFile, error) {
+	templateFileContent, err := os.ReadFile("shuttle.template.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("failed to find shuttle.template.yaml: %w", err)
+	}
+
+	var templateFile shuttleExtensionsFile
+	if err := yaml.Unmarshal(templateFileContent, &templateFile); err != nil {
+		return nil, fmt.Errorf("failed to parse shuttle.template.yaml: %w", err)
+	}
+
+	return &templateFile, nil
+}

--- a/internal/extensions/extensions.go
+++ b/internal/extensions/extensions.go
@@ -25,7 +25,30 @@ func (e *ExtensionsManager) Init(ctx context.Context) error {
 
 // GetAll will return all known and installed extensions
 func (e *ExtensionsManager) GetAll(ctx context.Context) ([]Extension, error) {
-	return nil, nil
+	registry := getRegistryPath(e.globalStore)
+
+	index := newRegistryIndex(registry)
+
+	registryExtensions, err := index.getExtensions(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to install extensions, could not get extensions from index: %w", err)
+	}
+
+	extensions := make([]Extension, 0)
+	for _, registryExtension := range registryExtensions {
+		registryExtension := registryExtension
+
+		extension, err := newExtensionFromRegistry(e.globalStore, &registryExtension)
+		if err != nil {
+			return nil, err
+		}
+
+		if extension != nil {
+			extensions = append(extensions, *extension)
+		}
+	}
+
+	return extensions, nil
 }
 
 // Install will ensure that all known extensions are installed and ready for use
@@ -53,7 +76,7 @@ func (e *ExtensionsManager) Install(ctx context.Context) error {
 
 // Update will fetch the latest extensions from a registry and install them afterwards so that they're ready for use
 func (e *ExtensionsManager) Update(ctx context.Context, registry string) error {
-	reg, err := NewRegistry(registry, e.globalStore)
+	reg, err := NewRegistryFromCombined(registry, e.globalStore)
 	if err != nil {
 		return fmt.Errorf("failed to update extensions: %w", err)
 	}
@@ -63,6 +86,24 @@ func (e *ExtensionsManager) Update(ctx context.Context, registry string) error {
 	}
 
 	if err := e.Install(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *ExtensionsManager) Publish(ctx context.Context, version string) error {
+	extensionsFile, err := getExtensionsFile(ctx)
+	if err != nil {
+		return err
+	}
+
+	registry, err := newGitHubRegistry()
+	if err != nil {
+		return err
+	}
+
+	if err := registry.Publish(ctx, extensionsFile, version); err != nil {
 		return err
 	}
 

--- a/internal/extensions/git_registry.go
+++ b/internal/extensions/git_registry.go
@@ -16,6 +16,11 @@ type gitRegistry struct {
 	globalStore *global.GlobalStore
 }
 
+// Publish isn't implemented yet for gitRegistry
+func (*gitRegistry) Publish(ctx context.Context, extFile *shuttleExtensionsFile, version string) error {
+	panic("unimplemented")
+}
+
 func (*gitRegistry) Get(ctx context.Context) error {
 	panic("unimplemented")
 }

--- a/internal/extensions/github_registry.go
+++ b/internal/extensions/github_registry.go
@@ -1,0 +1,324 @@
+package extensions
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+)
+
+type gitHubRegistry struct {
+	client *githubClient
+}
+
+func (g *gitHubRegistry) Publish(ctx context.Context, extFile *shuttleExtensionsFile, version string) error {
+	release, err := g.client.GetRelease(ctx, extFile, version)
+	if err != nil {
+		return err
+	}
+
+	sha, err := g.client.GetFileSHA(ctx, extFile)
+	if err != nil {
+		// TODO: Send error as a debug to log file somewhere
+		// Ignore file as it probably means that the file wasn't there
+	}
+
+	if err := g.client.UpsertFile(ctx, extFile, release, version, sha); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Get isn't implemented yet for GitHubRegistry
+func (*gitHubRegistry) Get(ctx context.Context) error {
+	panic("unimplemented")
+}
+
+// Update isn't implemented yet for GitHubRegistry
+func (*gitHubRegistry) Update(ctx context.Context) error {
+	panic("unimplemented")
+}
+
+func newGitHubRegistry() (Registry, error) {
+	client, err := newGitHubClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return &gitHubRegistry{
+		client: client,
+	}, nil
+}
+
+type githubClient struct {
+	accessToken string
+	httpClient  *http.Client
+}
+
+func newGitHubClient() (*githubClient, error) {
+	token, err := getGithubToken()
+	if err != nil {
+		return nil, err
+	}
+
+	return &githubClient{
+		accessToken: token,
+		httpClient:  http.DefaultClient,
+	}, nil
+}
+
+func (gc *githubClient) GetFileSHA(ctx context.Context, shuttleExtensionsFile *shuttleExtensionsFile) (string, error) {
+	owner, repo, ok := strings.Cut(*shuttleExtensionsFile.Registry.GitHub, "/")
+	if !ok {
+		return "", fmt.Errorf("failed to find owner and repo in registry: %s", *shuttleExtensionsFile.Registry.GitHub)
+	}
+
+	extensionsFile, err := githubClientDo[any, githubFileShaResp](
+		ctx,
+		gc,
+		http.MethodGet,
+		fmt.Sprintf(
+			"/repos/%s/%s/contents/%s",
+			owner,
+			repo,
+			getRemoteRegistryExtensionPathFile(shuttleExtensionsFile.Name),
+		),
+		nil,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return extensionsFile.Sha, nil
+}
+
+func (gc *githubClient) UpsertFile(ctx context.Context, shuttleExtensionsFile *shuttleExtensionsFile, releaseInformation *githubReleaseInformation, version string, sha string) error {
+	registryExtensionsReq := registryExtension{
+		Name:         shuttleExtensionsFile.Name,
+		Description:  shuttleExtensionsFile.Description,
+		Version:      version,
+		DownloadUrls: make([]registryExtensionDownloadLink, 0),
+	}
+
+	for _, releaseAsset := range releaseInformation.Assets {
+		arch, os, err := releaseAsset.ParseDownloadLink(shuttleExtensionsFile.Name)
+		if err != nil {
+			log.Printf("file did not match an actual binary: %s, %s", releaseAsset.DownloadUrl, err.Error())
+			continue
+		}
+
+		downloadLink := registryExtensionDownloadLink{
+			Architecture: arch,
+			Os:           os,
+			Url:          releaseAsset.Url,
+			Provider:     "github-release",
+		}
+
+		registryExtensionsReq.DownloadUrls = append(registryExtensionsReq.DownloadUrls, downloadLink)
+	}
+
+	upsertRequest, err := newGitHubUpsertRequest(
+		shuttleExtensionsFile.Name,
+		version,
+		registryExtensionsReq,
+		sha,
+	)
+	if err != nil {
+		return err
+	}
+
+	owner, repo, ok := strings.Cut(*shuttleExtensionsFile.Registry.GitHub, "/")
+	if !ok {
+		return fmt.Errorf("failed to find owner and repo in registry: %s", *shuttleExtensionsFile.Registry.GitHub)
+	}
+
+	_, err = githubClientDo[githubUpsertFileRequest, any](
+		ctx,
+		gc,
+		http.MethodPut,
+		fmt.Sprintf(
+			"/repos/%s/%s/contents/%s",
+			owner,
+			repo,
+			getRemoteRegistryExtensionPathFile(shuttleExtensionsFile.Name),
+		),
+		upsertRequest,
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (gc *githubClient) GetRelease(ctx context.Context, shuttleExtensionsFile *shuttleExtensionsFile, version string) (*githubReleaseInformation, error) {
+	release, err := githubClientDo[any, githubReleaseInformation](
+		ctx,
+		gc,
+		http.MethodGet,
+		fmt.Sprintf(
+			"/repos/%s/%s/releases/tags/%s",
+			shuttleExtensionsFile.Provider.GitHubRelease.Owner,
+			shuttleExtensionsFile.Provider.GitHubRelease.Repo,
+			version,
+		),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(release.Assets) == 0 {
+		return nil, errors.New("found no releases for github release")
+	}
+
+	return release, nil
+}
+
+type githubReleaseAsset struct {
+	DownloadUrl string `json:"browser_download_url"`
+	Url         string `json:"url"`
+}
+
+func (gra *githubReleaseAsset) ParseDownloadLink(name string) (arch string, os string, err error) {
+	components := strings.Split(gra.DownloadUrl, "/")
+	if len(components) < 3 {
+		return "", "", errors.New("failed to find a proper github download link")
+	}
+
+	file := components[len(components)-1]
+
+	rest, ok := strings.CutPrefix(file, name)
+	if !ok {
+		return "", "", errors.New("file link did not contain extension name")
+	}
+	rest = strings.TrimPrefix(rest, "-")
+
+	os, arch, ok = strings.Cut(rest, "-")
+	if !ok {
+		return "", "", errors.New("file did not match os-arch")
+	}
+
+	return arch, os, nil
+}
+
+type githubReleaseInformation struct {
+	Assets []githubReleaseAsset `json:"assets"`
+}
+
+type githubFileShaResp struct {
+	Sha string `json:"sha"`
+}
+
+type githubCommitter struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+type githubUpsertFileRequest struct {
+	Message   string          `json:"message"`
+	Committer githubCommitter `json:"committer"`
+	Content   string          `json:"content"`
+	Sha       *string         `json:"sha"`
+}
+
+func newGitHubUpsertRequest(name string, version string, registryExtensionsReq registryExtension, sha string) (*githubUpsertFileRequest, error) {
+	committerName := os.Getenv("GITHUB_COMMITTER_NAME")
+	if committerName == "" {
+		return nil, errors.New("GITHUB_COMMITTER_NAME was not found")
+	}
+
+	committerEmail := os.Getenv("GITHUB_COMMITTER_EMAIL")
+	if committerEmail == "" {
+		return nil, errors.New("GITHUB_COMMITTER_EMAIL was not found")
+	}
+
+	content, err := json.MarshalIndent(registryExtensionsReq, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+
+	contentB64 := base64.StdEncoding.EncodeToString(content)
+
+	req := &githubUpsertFileRequest{
+		Message: fmt.Sprintf("chore(extensions): updating %s to %s", name, version),
+		Committer: githubCommitter{
+			Name:  committerName,
+			Email: committerEmail,
+		},
+		Content: contentB64,
+	}
+
+	if sha != "" {
+		req.Sha = &sha
+	}
+
+	return req, nil
+}
+
+func githubClientDo[TReq any, TResp any](ctx context.Context, githubClient *githubClient, method string, path string, reqBody *TReq) (*TResp, error) {
+	var bodyReader io.Reader
+	if reqBody != nil {
+		contents, err := json.Marshal(reqBody)
+		if err != nil {
+			return nil, err
+		}
+
+		bodyReader = bytes.NewReader(contents)
+	}
+
+	url := fmt.Sprintf("https://api.github.com/%s", strings.TrimPrefix(path, "/"))
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		method,
+		url,
+		bodyReader,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Accept", "application/vnd.github+json")
+	req.Header.Add("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", githubClient.accessToken))
+
+	resp, err := githubClient.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respContent, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode > 399 {
+		var message githubMessage
+		if err := json.Unmarshal(respContent, &message); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal resp: %w", err)
+		}
+
+		return nil, fmt.Errorf("failed github request with: %s", message.Message)
+	}
+
+	var returnObject TResp
+	if err := json.Unmarshal(respContent, &returnObject); err != nil {
+		return nil, err
+	}
+
+	return &returnObject, nil
+}
+
+type githubMessage struct {
+	Message string `json:"message"`
+}

--- a/internal/extensions/github_token.go
+++ b/internal/extensions/github_token.go
@@ -1,0 +1,42 @@
+package extensions
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func getGithubToken() (string, error) {
+	if accessToken := os.Getenv("SHUTTLE_EXTENSIONS_GITHUB_ACCESS_TOKEN"); accessToken != "" {
+		return accessToken, nil
+	} else if accessToken := os.Getenv("GITHUB_ACCESS_TOKEN"); accessToken != "" {
+		return accessToken, nil
+	} else {
+		accessToken, err := getToken()
+		if err != nil {
+			return "", err
+		}
+
+		return accessToken, nil
+	}
+}
+
+func getToken() (string, error) {
+	tokenRaw, err := exec.Command("gh", "auth", "token").Output()
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return "", errors.New("github-cli (gh) is not installed")
+		}
+
+		return "", err
+	}
+
+	token := string(tokenRaw)
+
+	if token != "" {
+		return strings.TrimSpace(token), nil
+	}
+
+	return "", errors.New("no github token available (please sign in `gh auth login`)")
+}

--- a/internal/extensions/registry.go
+++ b/internal/extensions/registry.go
@@ -12,10 +12,11 @@ import (
 type Registry interface {
 	Get(ctx context.Context) error
 	Update(ctx context.Context) error
+	Publish(ctx context.Context, extFile *shuttleExtensionsFile, version string) error
 }
 
-// NewRegistry is a shim for concrete implementations of the registries, such as gitRegistry
-func NewRegistry(registry string, globalStore *global.GlobalStore) (Registry, error) {
+// NewRegistryFromCombined is a shim for concrete implementations of the registries, such as gitRegistry
+func NewRegistryFromCombined(registry string, globalStore *global.GlobalStore) (Registry, error) {
 	registryType, registryUrl, ok := strings.Cut(registry, "=")
 	if !ok {
 		return nil, fmt.Errorf("registry was not a valid url: %s", registry)

--- a/internal/extensions/registry_index.go
+++ b/internal/extensions/registry_index.go
@@ -36,7 +36,7 @@ func newRegistryIndex(registryPath string) *registryIndex {
 	}
 }
 
-func (r *registryIndex) getExtensions(ctx context.Context) ([]registryExtension, error) {
+func (r *registryIndex) getExtensions(_ context.Context) ([]registryExtension, error) {
 	contents, err := os.ReadDir(r.getIndexPath())
 	if err != nil {
 		return nil, fmt.Errorf("failed to list index in registry: %s, %w", r.getIndexPath(), err)

--- a/internal/extensions/remote_registry.go
+++ b/internal/extensions/remote_registry.go
@@ -1,0 +1,9 @@
+package extensions
+
+import "context"
+
+type RemoteRegistry interface {
+	Publish(ctx context.Context) error
+}
+
+func NewRemoteRegistry(registry string) {}

--- a/internal/extensions/remote_registry_paths.go
+++ b/internal/extensions/remote_registry_paths.go
@@ -1,0 +1,15 @@
+package extensions
+
+import "path"
+
+func getRemoteRegistryIndex() string {
+	return "index"
+}
+
+func getRemoteRegistryExtensionPath(name string) string {
+	return path.Join(getRemoteRegistryIndex(), name)
+}
+
+func getRemoteRegistryExtensionPathFile(name string) string {
+	return path.Join(getRemoteRegistryExtensionPath(name), "shuttle-extension.json")
+}


### PR DESCRIPTION
This specifically adds a downloader for github releases it uses either the

SHUTTLE_EXTENSIONS_GITHUB_ACCESS_TOKEN or GITHUB_ACCESS_TOKEN for access to the releases

The downloader expects a full url from the registry as seen in a previous pr

Builds on #223
