### PR TITLE
fix: git chosen requires tag for checkout

### DIFF
--- a/cmd/plan_test.go
+++ b/cmd/plan_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -19,6 +20,11 @@ func TestPlan(t *testing.T) {
 			stdoutput: "https://github.com/lunarway/shuttle-example-go-plan.git",
 			erroutput: "Cloning plan https://github.com/lunarway/shuttle-example-go-plan.git\n",
 			err:       nil,
+		},
+		{
+			name:    "git plan invalid checkout",
+			input:   args("-p", "testdata/project-git", "--plan", "something-invalid", "plan"),
+			initErr: errors.New("Plan argument wasn't valid for a git plan: something-invalid"),
 		},
 		{
 			name:      "no plan with template",

--- a/cmd/plan_test.go
+++ b/cmd/plan_test.go
@@ -24,7 +24,7 @@ func TestPlan(t *testing.T) {
 		{
 			name:    "git plan invalid checkout",
 			input:   args("-p", "testdata/project-git", "--plan", "something-invalid", "plan"),
-			initErr: errors.New("Plan argument wasn't valid for a git plan: something-invalid"),
+			initErr: errors.New("Plan argument wasn't valid for a git plan (#<branch / tag name>): something-invalid"),
 		},
 		{
 			name:      "no plan with template",

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -83,9 +83,13 @@ func GetGitPlan(
 ) (string, error) {
 	parsedGitPlan := ParsePlan(plan)
 
-	if strings.HasPrefix(planArgument, "#") {
-		parsedGitPlan.Head = planArgument[1:]
-		uii.EmphasizeInfoln("Overload git plan branch/tag/sha with %v", parsedGitPlan.Head)
+	if planArgument != "" {
+		if strings.HasPrefix(planArgument, "#") {
+			parsedGitPlan.Head = planArgument[1:]
+			uii.EmphasizeInfoln("Overload git plan branch/tag/sha with %v", parsedGitPlan.Head)
+		} else {
+			return "", fmt.Errorf("Plan argument wasn't valid for a git plan: %s", planArgument)
+		}
 	}
 
 	planPath := path.Join(localShuttleDirectoryPath, "plan")

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -88,7 +88,7 @@ func GetGitPlan(
 			parsedGitPlan.Head = planArgument[1:]
 			uii.EmphasizeInfoln("Overload git plan branch/tag/sha with %v", parsedGitPlan.Head)
 		} else {
-			return "", fmt.Errorf("Plan argument wasn't valid for a git plan: %s", planArgument)
+			return "", fmt.Errorf("Plan argument wasn't valid for a git plan (#<branch / tag name>): %s", planArgument)
 		}
 	}
 


### PR DESCRIPTION
This is because if we accept values it will not be interpreted, and for git it means falling back on head, which is usually master

We'd rather want it to fail instead

Fixes: AURA-1896
