### PR TITLE
fix: shuttle actions currently reports issues double, we don't want that

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/lunarway/shuttle/pkg/config"
+	"github.com/lunarway/shuttle/pkg/errors"
 	"github.com/lunarway/shuttle/pkg/executors"
 	"github.com/lunarway/shuttle/pkg/ui"
 )
@@ -177,9 +178,10 @@ func newRunSubCommand(
 	}
 
 	cmd := &cobra.Command{
-		Use:   script,
-		Short: value.Description,
-		Long:  value.Description,
+		Use:          script,
+		Short:        value.Description,
+		Long:         value.Description,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if *interactiveArg {
 				uii.Verboseln("Running using interactive mode!")
@@ -204,7 +206,7 @@ func newRunSubCommand(
 			err := executorRegistry.Execute(ctx, context, script, actualArgs, *validateArgs)
 			if err != nil {
 				traceError(err)
-				return err
+				return errors.NewExitCode(1, "cmd failed: %s", err.Error())
 			}
 
 			return nil

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/lunarway/shuttle/pkg/config"
-	"github.com/lunarway/shuttle/pkg/errors"
 	"github.com/lunarway/shuttle/pkg/executors"
 	"github.com/lunarway/shuttle/pkg/ui"
 )
@@ -206,7 +205,7 @@ func newRunSubCommand(
 			err := executorRegistry.Execute(ctx, context, script, actualArgs, *validateArgs)
 			if err != nil {
 				traceError(err)
-				return errors.NewExitCode(1, "cmd failed: %s", err.Error())
+				return err
 			}
 
 			return nil

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -8,30 +8,6 @@ import (
 )
 
 func TestRun(t *testing.T) {
-
-	usage := `Usage:
-  shuttle run required_arg [flags]
-
-Flags:
-      --foo string   
-  -h, --help         help for required_arg
-
-Global Flags:
-  -c, --clean             Start from clean setup
-      --interactive       sets whether to enable ui for getting missing values via. prompt instead of failing immediadly, default is set by [SHUTTLE_INTERACTIVE=true/false]
-      --plan string       Overload the plan used.
-                          Specifying a local path with either an absolute path (/some/plan) or a relative path (../some/plan) to another location
-                          for the selected plan.
-                          Select a version of a git plan by using #branch, #sha or #tag
-                          If none of above is used, then the argument will expect a full plan spec.
-  -p, --project string    Project path (default ".")
-      --skip-pull         Skip git plan pulling step
-      --template string   Template string to use. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
-      --validate          Validate arguments against script definition in plan and exit with 1 on unknown or missing arguments (default true)
-  -v, --verbose           Print verbose output
-
-`
-
 	pwd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("Failed to get working directory: %v", err)
@@ -60,29 +36,9 @@ Global Flags:
 			err:       nil,
 		},
 		{
-			name:  "exit 1",
-			input: args("-p", "testdata/project", "run", "exit_1"),
-			stdoutput: `Usage:
-  shuttle run exit_1 [flags]
-
-Flags:
-  -h, --help   help for exit_1
-
-Global Flags:
-  -c, --clean             Start from clean setup
-      --interactive       sets whether to enable ui for getting missing values via. prompt instead of failing immediadly, default is set by [SHUTTLE_INTERACTIVE=true/false]
-      --plan string       Overload the plan used.
-                          Specifying a local path with either an absolute path (/some/plan) or a relative path (../some/plan) to another location
-                          for the selected plan.
-                          Select a version of a git plan by using #branch, #sha or #tag
-                          If none of above is used, then the argument will expect a full plan spec.
-  -p, --project string    Project path (default ".")
-      --skip-pull         Skip git plan pulling step
-      --template string   Template string to use. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
-      --validate          Validate arguments against script definition in plan and exit with 1 on unknown or missing arguments (default true)
-  -v, --verbose           Print verbose output
-
-`,
+			name:      "exit 1",
+			input:     args("-p", "testdata/project", "run", "exit_1"),
+			stdoutput: ``,
 			erroutput: "Error: exit code 4 - Failed executing script `exit_1`: shell script `exit 1`\nExit code: 1\n",
 			err: errors.New(
 				"exit code 4 - Failed executing script `exit_1`: shell script `exit 1`\nExit code: 1",
@@ -107,7 +63,7 @@ Global Flags:
 		{
 			name:      "script fails when required argument is missing",
 			input:     args("-p", "testdata/project", "run", "required_arg"),
-			stdoutput: usage,
+			stdoutput: "",
 			erroutput: `Error: Error: required flag(s) "foo" not set
 `,
 			err: errors.New(`Error: required flag(s) "foo" not set`),
@@ -150,7 +106,7 @@ Global Flags:
 		{
 			name:      "script fails on unkown argument",
 			input:     args("-p", "testdata/project", "run", "required_arg", "foo=bar", "--a b"),
-			stdoutput: usage,
+			stdoutput: "",
 			erroutput: `Error: unknown flag: --a b
 `,
 			err: errors.New(`unknown flag: --a b`),

--- a/pkg/executors/golang/cmder/cmder.go
+++ b/pkg/executors/golang/cmder/cmder.go
@@ -47,7 +47,7 @@ func (rc *RootCmd) TryExecute(args []string) error {
 		&cobra.Command{
 			Hidden: true,
 			Use:    "lsjson",
-			RunE: func(cmd *cobra.Command, args []string) error {
+			Run: func(cmd *cobra.Command, args []string) {
 				actions := executer.NewActions()
 				for _, cmd := range rc.Cmds {
 					args := make([]executer.ActionArg, 0)
@@ -65,16 +65,16 @@ func (rc *RootCmd) TryExecute(args []string) error {
 
 				rawJson, err := json.Marshal(actions)
 				if err != nil {
-					return err
+					log.Fatal(err)
 				}
 
 				// Prints the commands and args as json to stdout
 				_, err = fmt.Printf("%s", string(rawJson))
 				if err != nil {
-					return err
+					log.Fatal(err)
 				}
 
-				return nil
+				return
 			},
 		},
 	)
@@ -85,9 +85,9 @@ func (rc *RootCmd) TryExecute(args []string) error {
 
 		cobracmd := &cobra.Command{
 			Use: cmd.Name,
-			RunE: func(cobracmd *cobra.Command, args []string) error {
+			Run: func(cobracmd *cobra.Command, args []string) {
 				if err := cobracmd.ParseFlags(args); err != nil {
-					return err
+					log.Fatal(err)
 				}
 
 				inputs := make([]reflect.Value, 0, len(cmd.Args)+1)
@@ -101,19 +101,19 @@ func (rc *RootCmd) TryExecute(args []string) error {
 					Call(inputs)
 
 				if len(returnValues) == 0 {
-					return nil
+					return
 				}
 
 				for _, val := range returnValues {
 					if val.Type().Implements(reflect.TypeOf((*error)(nil)).Elem()) {
 						err, ok := val.Interface().(error)
 						if ok && err != nil {
-							return err
+							log.Fatal(err)
 						}
 					}
 				}
 
-				return nil
+				return
 			},
 		}
 		for i, arg := range cmd.Args {

--- a/pkg/executors/golang/cmder/cmder_test.go
+++ b/pkg/executors/golang/cmder/cmder_test.go
@@ -21,7 +21,7 @@ func TestCmderWithError(t *testing.T) {
 
 	err := cmder.NewRoot().AddCmds(testFunc).TryExecute(args)
 
-	assert.ErrorContains(t, err, "some-error")
+	assert.ErrorIs(t, err, cmder.ErrNoHelp)
 }
 
 func TestCmderWithNoError(t *testing.T) {
@@ -63,7 +63,7 @@ func TestCmderWithMultipeReturnsErroring(t *testing.T) {
 
 	err := cmder.NewRoot().AddCmds(testFunc).TryExecute(args)
 
-	assert.ErrorContains(t, err, "some-error")
+	assert.ErrorIs(t, err, cmder.ErrNoHelp)
 }
 
 func TestCmderWithMultipeReturnsErroringInAnyPlace(t *testing.T) {
@@ -77,5 +77,5 @@ func TestCmderWithMultipeReturnsErroringInAnyPlace(t *testing.T) {
 
 	err := cmder.NewRoot().AddCmds(testFunc).TryExecute(args)
 
-	assert.ErrorContains(t, err, "some-error")
+	assert.ErrorIs(t, err, cmder.ErrNoHelp)
 }


### PR DESCRIPTION
Currently shuttle actions will report the same error twice, we should just return exit 1 (which log.Fatal does)
