### PR TITLE
feat/silence usage for shuttle actions

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -157,7 +157,7 @@ func newRunSubCommand(
 				}
 
 			} else if *inputArgs[arg.Name] == "" && arg.Required && *validateArgs {
-				return fmt.Errorf("Error: required flag(s) \"%s\" not set", argName(arg.Name))
+				return fmt.Errorf("required flag(s) \"%s\" not set", argName(arg.Name))
 			}
 		}
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -64,9 +64,9 @@ func TestRun(t *testing.T) {
 			name:      "script fails when required argument is missing",
 			input:     args("-p", "testdata/project", "run", "required_arg"),
 			stdoutput: "",
-			erroutput: `Error: Error: required flag(s) "foo" not set
+			erroutput: `Error: required flag(s) "foo" not set
 `,
-			err: errors.New(`Error: required flag(s) "foo" not set`),
+			err: errors.New(`required flag(s) "foo" not set`),
 		},
 		{
 			name:      "script succeeds with required argument",

--- a/pkg/executors/golang/cmder/cmder.go
+++ b/pkg/executors/golang/cmder/cmder.go
@@ -40,7 +40,6 @@ func (rc *RootCmd) Execute() {
 		} else {
 			log.Fatalf("%v\n", err)
 		}
-
 	}
 }
 
@@ -123,7 +122,7 @@ func (rc *RootCmd) TryExecute(args []string) error {
 					if val.Type().Implements(reflect.TypeOf((*error)(nil)).Elem()) {
 						err, ok := val.Interface().(error)
 						if ok && err != nil {
-							log.Println(err)
+							fmt.Fprintln(cobracmd.ErrOrStderr(), err)
 							return ErrNoHelp
 						}
 					}
@@ -133,8 +132,8 @@ func (rc *RootCmd) TryExecute(args []string) error {
 			},
 		}
 		for i, arg := range cmd.Args {
-			cobracmd.PersistentFlags().StringVar(&parameters[i], arg.Name, "", "")
-			_ = cobracmd.MarkPersistentFlagRequired(arg.Name)
+			cobracmd.Flags().StringVar(&parameters[i], arg.Name, "", "")
+			_ = cobracmd.MarkFlagRequired(arg.Name)
 		}
 
 		rootcmd.AddCommand(cobracmd)

--- a/pkg/executors/golang/cmder/cmder.go
+++ b/pkg/executors/golang/cmder/cmder.go
@@ -95,6 +95,10 @@ func (rc *RootCmd) TryExecute(args []string) error {
 
 		cobracmd := &cobra.Command{
 			Use: cmd.Name,
+
+			// We don't want to show the full usage, instead just show the error
+			SilenceUsage: true,
+
 			RunE: func(cobracmd *cobra.Command, args []string) error {
 				if err := cobracmd.ParseFlags(args); err != nil {
 					log.Println(err)


### PR DESCRIPTION
This is a simple change which basically is just there to prevent double outputs when running the code from shuttle actions. 

Previously we printed the usage of the code, but that is redundant as you can just as well run --help or something to get the output, we don't want to expose to the user, that the shuttle actions are actually go binaries underneath
