### PR TITLE
👮 Support adding a specific clone token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor/
 shuttle
 .shuttle
 .idea
+.DS_Store

--- a/action.yml
+++ b/action.yml
@@ -1,12 +1,14 @@
-name: 'Install Shuttle'
-description: 'Installs Lunar Shuttle'
+name: "Install Shuttle"
+description: "Installs Lunar Shuttle"
 runs:
   using: "composite"
   steps:
     - run: |
+        set -e
+
         if [ "$(uname)" == "Darwin" ]; then
             mkdir -p ~/bin
-            
+
             if [[ $(uname -m) == 'arm64' ]]; then
                 curl -LO https://github.com/lunarway/shuttle/releases/download/$(curl -Lso /dev/null -w %{url_effective} https://github.com/lunarway/shuttle/releases/latest | awk -F'/' '{print $NF}')/shuttle-darwin-arm64
                 chmod +x shuttle-darwin-arm64

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -161,7 +161,12 @@ func GetGitPlan(
 
 		var cloneArg string
 		if parsedGitPlan.Protocol == "https" {
-			cloneArg = "https://" + parsedGitPlan.Repository
+			cloneToken := os.GetEnv("HTTPS_ACCESS_TOKEN")
+			if cloneToken == "" {
+				cloneArg = "https://" + parsedGitPlan.Repository
+			} else {
+				cloneArg = "https://" + cloneToken + ":" + parsedGitPlan.Repository
+			}
 		} else if parsedGitPlan.Protocol == "ssh" {
 			cloneArg = parsedGitPlan.User + "@" + parsedGitPlan.Repository
 		} else {


### PR DESCRIPTION
# Overall Idea
Some shuttle repositories might not be accessible from the runner, e.g. if all repositories are placed in a private GitHub organisation. Historically this has been solved by overriding the clone path in the GitHub Action like so: 
```
- name: Test
  run: shuttle run test_framework github_token=${{ secrets.GITHUB_TOKEN }} --plan https://${{ secrets.IOS_BOT_TOKEN }}@github.com/lunarway/shuttle-ios-plan.git#main
```

Instead we would like to just being able to use the plan specified in the shuttle file and just set a access token from inside the action instead, making it look like this:
```
- name: Build
  run: shuttle run build_framework
  env:
    HTTPS_CLONE_TOKEN: ${{ steps.token.outputs.token }}
```