### PR TITLE
:bug: Clone token should be set using @

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -165,7 +165,7 @@ func GetGitPlan(
 			if cloneToken == "" {
 				cloneArg = "https://" + parsedGitPlan.Repository
 			} else {
-				cloneArg = fmt.Sprintf("https://%s:%s", cloneToken, parsedGitPlan.Repository)
+				cloneArg = fmt.Sprintf("https://%s@%s", cloneToken, parsedGitPlan.Repository)
 			}
 		} else if parsedGitPlan.Protocol == "ssh" {
 			cloneArg = parsedGitPlan.User + "@" + parsedGitPlan.Repository


### PR DESCRIPTION
Right now the token is set like `https://TOKEN:github` - which is wrong. It should be `https://TOKEN@github`