### PR TITLE
chore: transfer ownership to squad-dark-matter

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @lunarway/squad-esa
+* @lunarway/squad-dark-matter

--- a/shuttle.yaml
+++ b/shuttle.yaml
@@ -2,7 +2,7 @@ plan: false
 vars:
   service: shuttle
   domain: developer-productivity
-  squad: esa
+  squad: dark-matter
 
 scripts:
   build:


### PR DESCRIPTION
Updates CODEOWNERS and shuttle.yaml to point to squad-dark-matter.

Part of [DMAT-8](https://linear.app/lunar/issue/DMAT-8).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates ownership/config metadata with no runtime code or logic changes.
> 
> **Overview**
> Transfers repository ownership/configuration from squad `esa` to `dark-matter` by updating `CODEOWNERS` and the `squad` value in `shuttle.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 178fd56d074c505cf4556db605f11b7ae5b3e008. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->