### PR TITLE
docs: add build from source section and fix install snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,11 +223,14 @@ chmod +x shuttle
 sudo mv shuttle /usr/local/bin/shuttle
 ```
 
-To install for your user only, without `sudo`, put it in a directory on your
-`PATH` such as `~/.local/bin` instead:
+To install for your user only, without `sudo`, move it to `~/.local/bin`
+instead. Unlike `/usr/local/bin` that directory is not on the `PATH` by
+default, so add it if it isn't already:
 
 ```console
+mkdir -p ~/.local/bin
 mv shuttle ~/.local/bin/shuttle
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
 ```
 
 ### Linux

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - [Features](#features)
 - [Documentation](#documentation)
 - [Installing](#installing)
+- [Building from source](#building-from-source)
 - [Functions](#functions)
 - [Release History](#release-history)
 
@@ -208,28 +209,40 @@ Following arguments are supported
 
 ### Mac OS
 
+On an Apple Silicon Mac (M1 and newer) use the `arm64` binary, on an Intel Mac
+use the `amd64` one:
+
 ```console
-curl -LO https://github.com/lunarway/shuttle/releases/download/$(curl -Lso /dev/null -w %{url_effective} https://github.com/lunarway/shuttle/releases/latest | grep -o '[^/]*$')/shuttle-darwin-amd64
-chmod +x shuttle-darwin-amd64
-sudo mv shuttle-darwin-amd64 /usr/local/bin/shuttle
+# Apple Silicon
+curl -Lo shuttle https://github.com/lunarway/shuttle/releases/latest/download/shuttle-darwin-arm64
+
+# Intel
+curl -Lo shuttle https://github.com/lunarway/shuttle/releases/latest/download/shuttle-darwin-amd64
+
+chmod +x shuttle
+sudo mv shuttle /usr/local/bin/shuttle
 ```
 
-#### Mac OS Sonoma (broke grep)
-
-Use ripgrep instead (rg)
+To install for your user only, without `sudo`, put it in a directory on your
+`PATH` such as `~/.local/bin` instead:
 
 ```console
-curl -LO https://github.com/lunarway/shuttle/releases/download/$(curl -Lso /dev/null -w %{url_effective} https://github.com/lunarway/shuttle/releases/latest | rg -o '[^/]*$')/shuttle-darwin-amd64
-chmod +x shuttle-darwin-amd64
-sudo mv shuttle-darwin-amd64 /usr/local/bin/shuttle
+mv shuttle ~/.local/bin/shuttle
 ```
 
 ### Linux
 
+On `x86_64` use the `amd64` binary, on `aarch64` use the `arm64` one:
+
 ```console
-curl -LO https://github.com/lunarway/shuttle/releases/download/$(curl -Lso /dev/null -w %{url_effective} https://github.com/lunarway/shuttle/releases/latest | grep -o '[^/]*$')/shuttle-linux-amd64
-chmod +x shuttle-linux-amd64
-sudo mv shuttle-linux-amd64 /usr/local/bin/shuttle
+# x86_64
+curl -Lo shuttle https://github.com/lunarway/shuttle/releases/latest/download/shuttle-linux-amd64
+
+# aarch64
+curl -Lo shuttle https://github.com/lunarway/shuttle/releases/latest/download/shuttle-linux-arm64
+
+chmod +x shuttle
+sudo mv shuttle /usr/local/bin/shuttle
 ```
 
 ### GitHub Actions
@@ -242,6 +255,54 @@ workflow:
 ```
 
 After this point you can use shuttle in the scripts in your workflow job.
+
+## Building from source
+
+Building requires [Go](https://go.dev/dl/) (see `go.mod` for the minimum
+version). The simplest build produces a `shuttle` binary for your current
+platform:
+
+```console
+go build
+# or, with shuttle itself
+shuttle run build
+```
+
+To include version information as reported by `shuttle version`, set the
+`ldflags` used by the release build:
+
+```console
+CGO_ENABLED=0 go build \
+  -ldflags "-s -w -X github.com/lunarway/shuttle/cmd.version=$(git describe --tags) -X github.com/lunarway/shuttle/cmd.commit=$(git rev-parse HEAD)" \
+  -o shuttle .
+```
+
+### Cross compiling
+
+Set `GOOS` and `GOARCH` to build for another platform, eg. macOS and Linux:
+
+```console
+GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o shuttle-darwin-arm64 .
+GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o shuttle-darwin-amd64 .
+GOOS=linux  GOARCH=amd64 CGO_ENABLED=0 go build -o shuttle-linux-amd64 .
+```
+
+Note that macOS binaries built this way are not code signed or notarized, so
+Gatekeeper blocks them when copied to another machine. Clear the quarantine
+attribute to run them:
+
+```console
+xattr -d com.apple.quarantine shuttle-darwin-arm64
+```
+
+### All release artifacts
+
+Releases are built with [GoReleaser](https://goreleaser.com) based on
+`.goreleaser.yml`. To build all supported platforms locally into `dist/`:
+
+```console
+goreleaser build --snapshot --clean
+```
 
 ## Functions
 


### PR DESCRIPTION
Documents how to build a `shuttle` binary locally, and fixes the install snippets.

## Building from source

New section covering:

- plain `go build` / `shuttle run build`
- the release `ldflags` so `shuttle version` reports a version and commit
- cross compiling via `GOOS`/`GOARCH`
- the Gatekeeper quarantine caveat for unsigned macOS binaries
- `goreleaser build --snapshot --clean` for all release artifacts

## Install snippets

The macOS snippet hardcoded `shuttle-darwin-amd64`, which fails with `Bad CPU type in executable` on Apple Silicon without Rosetta. Both the macOS and Linux sections now show the binary per architecture, and add a no-`sudo` `~/.local/bin` option for macOS.

Both sections also switch from parsing the `releases/latest` redirect with `grep -o '[^/]*$'` to `releases/latest/download/…`. That removes the "Mac OS Sonoma (broke grep)" ripgrep workaround the old approach needed.

## Testing

- Built arm64 binaries with the documented `go build` and `go install` commands; `file` reports `Mach-O 64-bit executable arm64` and `shuttle version` prints the injected version.
- Ran the new macOS download snippet end to end; the downloaded binary reports `0.25.0`.
- All four asset URLs (`darwin-arm64`, `darwin-amd64`, `linux-amd64`, `linux-arm64`) return 200.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or application code impact.
> 
> **Overview**
> **README** install instructions now pick the right release binary per architecture (macOS `arm64`/`amd64`, Linux `amd64`/`arm64`), download via `releases/latest/download/…` instead of parsing the latest redirect with `grep`, and document a no-`sudo` `~/.local/bin` install. The Sonoma **ripgrep** workaround section is removed with that URL change.
> 
> A new **Building from source** section (linked from the table of contents) covers plain `go build` / `shuttle run build`, release-style `ldflags` for `shuttle version`, cross-compilation with `GOOS`/`GOARCH`, Gatekeeper quarantine notes for unsigned macOS builds, and `goreleaser build --snapshot --clean` for local release artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9d4c831a597880839b520965f53a15c271103c7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->