### PR TITLE
fix(action): resolve arch for linux and write an expanded PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,22 +270,6 @@ workflow:
 
 After this point you can use shuttle in the scripts in your workflow job.
 
-Set the `lifecycle` input to also prepare the plan, which saves a separate
-`shuttle prepare` step. The SHA of the prepared plan is exposed as the
-`shuttle_plan_sha` output:
-
-```yaml
-- uses: lunarway/shuttle
-  id: shuttle
-  with:
-    lifecycle: stable
-
-- run: echo "prepared plan ${{ steps.shuttle.outputs.shuttle_plan_sha }}"
-```
-
-Note that preparing the plan requires the repository to be checked out first,
-as shuttle reads the `shuttle.yaml` file in the working directory.
-
 ## Building from source
 
 Building requires [Go](https://go.dev/dl/) (see `go.mod` for the minimum

--- a/README.md
+++ b/README.md
@@ -264,11 +264,27 @@ sudo mv shuttle /usr/local/bin/shuttle
 Shuttle can be installed on your GitHub Runner by adding this line to your
 workflow:
 
-```
-- use: lunarway/shuttle
+```yaml
+- uses: lunarway/shuttle
 ```
 
 After this point you can use shuttle in the scripts in your workflow job.
+
+Set the `lifecycle` input to also prepare the plan, which saves a separate
+`shuttle prepare` step. The SHA of the prepared plan is exposed as the
+`shuttle_plan_sha` output:
+
+```yaml
+- uses: lunarway/shuttle
+  id: shuttle
+  with:
+    lifecycle: stable
+
+- run: echo "prepared plan ${{ steps.shuttle.outputs.shuttle_plan_sha }}"
+```
+
+Note that preparing the plan requires the repository to be checked out first,
+as shuttle reads the `shuttle.yaml` file in the working directory.
 
 ## Building from source
 

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,9 @@ runs:
             *) echo "Unsupported operating system: $(uname -s)" >&2; exit 1 ;;
         esac
 
-        curl -fsSLo shuttle https://github.com/lunarway/shuttle/releases/latest/download/shuttle-$os-$arch
+        curl -fsSLo shuttle \
+            --retry 5 --retry-delay 5 --retry-all-errors \
+            https://github.com/lunarway/shuttle/releases/latest/download/shuttle-$os-$arch
         chmod +x shuttle
 
         if [ "$os" == "darwin" ]; then

--- a/action.yml
+++ b/action.yml
@@ -1,14 +1,5 @@
 name: "Install Shuttle"
 description: "Installs Lunar Shuttle"
-inputs:
-  lifecycle:
-    description: "Prepare the plan at this lifecycle, eg. experimental or stable. Skips prepare when empty."
-    required: false
-    default: ""
-outputs:
-  shuttle_plan_sha:
-    description: "The SHA of the prepared shuttle plan. Empty when lifecycle is not set."
-    value: ${{ steps.prepare.outputs.shuttle_plan_sha }}
 runs:
   using: "composite"
   steps:
@@ -42,15 +33,4 @@ runs:
         fi
 
         shuttle version
-      shell: bash
-
-    - id: prepare
-      if: inputs.lifecycle != ''
-      run: |
-        set -euo pipefail
-
-        shuttle prepare --plan "#${{ inputs.lifecycle }}"
-
-        shuttle_plan_sha=$(git -C .shuttle/plan rev-parse HEAD)
-        echo "shuttle_plan_sha=${shuttle_plan_sha}" >> $GITHUB_OUTPUT
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -6,28 +6,29 @@ runs:
     - run: |
         set -e
 
-        VERSION=$(curl -fLso /dev/null -w '%{url_effective}' https://github.com/lunarway/shuttle/releases/latest) || { echo "Failed to fetch latest release version" >&2; exit 1; }
-        VERSION=${VERSION##*/}
+        case "$(uname -m)" in
+            arm64|aarch64) arch=arm64 ;;
+            x86_64|amd64)  arch=amd64 ;;
+            *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+        esac
 
-        if [ "$(uname)" == "Darwin" ]; then
-            mkdir -p ~/bin
+        case "$(uname -s)" in
+            Darwin) os=darwin ;;
+            Linux)  os=linux ;;
+            *) echo "Unsupported operating system: $(uname -s)" >&2; exit 1 ;;
+        esac
 
-            if [[ $(uname -m) == 'arm64' ]]; then
-                curl -fLO https://github.com/lunarway/shuttle/releases/download/${VERSION}/shuttle-darwin-arm64
-                chmod +x shuttle-darwin-arm64
-                mv shuttle-darwin-arm64 ~/bin/shuttle
-            else
-                curl -fLO https://github.com/lunarway/shuttle/releases/download/${VERSION}/shuttle-darwin-amd64
-                chmod +x shuttle-darwin-amd64
-                mv shuttle-darwin-amd64 ~/bin/shuttle
-            fi
+        curl -fsSLo shuttle https://github.com/lunarway/shuttle/releases/latest/download/shuttle-$os-$arch
+        chmod +x shuttle
 
-            echo "~/bin/" >> $GITHUB_PATH
-            export PATH=$PATH:~/bin
-        elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-            curl -fLO https://github.com/lunarway/shuttle/releases/download/${VERSION}/shuttle-linux-amd64
-            chmod +x shuttle-linux-amd64
-            mv shuttle-linux-amd64 /usr/local/bin/shuttle
+        if [ "$os" == "darwin" ]; then
+            mkdir -p "$HOME/bin"
+            mv shuttle "$HOME/bin/shuttle"
+            echo "$HOME/bin" >> $GITHUB_PATH
+            export PATH="$HOME/bin:$PATH"
+        else
+            mv shuttle /usr/local/bin/shuttle
         fi
+
         shuttle version
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,14 @@
 name: "Install Shuttle"
 description: "Installs Lunar Shuttle"
+inputs:
+  lifecycle:
+    description: "Prepare the plan at this lifecycle, eg. experimental or stable. Skips prepare when empty."
+    required: false
+    default: ""
+outputs:
+  shuttle_plan_sha:
+    description: "The SHA of the prepared shuttle plan. Empty when lifecycle is not set."
+    value: ${{ steps.prepare.outputs.shuttle_plan_sha }}
 runs:
   using: "composite"
   steps:
@@ -33,4 +42,15 @@ runs:
         fi
 
         shuttle version
+      shell: bash
+
+    - id: prepare
+      if: inputs.lifecycle != ''
+      run: |
+        set -euo pipefail
+
+        shuttle prepare --plan "#${{ inputs.lifecycle }}"
+
+        shuttle_plan_sha=$(git -C .shuttle/plan rev-parse HEAD)
+        echo "shuttle_plan_sha=${shuttle_plan_sha}" >> $GITHUB_OUTPUT
       shell: bash


### PR DESCRIPTION
Two bugs in the install script, plus a simplification.

## Linux was hardcoded to amd64

`shuttle-linux-amd64` was downloaded unconditionally on Linux, so arm64 runners got an x86_64 binary. The release publishes `shuttle-linux-arm64`, so `os` and `arch` are now resolved from `uname` for both platforms, with an explicit failure on anything unsupported.

## GITHUB_PATH got a literal tilde

The macOS branch did `echo "~/bin/" >> $GITHUB_PATH`. GitHub reads that file verbatim without shell expansion, so the resulting PATH entry never resolved to a real directory. It went unnoticed because the same step also exported an expanded `PATH`, making `shuttle version` pass locally while later steps would fail with `shuttle: command not found`. Now writes `$HOME/bin`.

## Download URL

Replaced the `releases/latest` redirect scraping with `releases/latest/download/…`, which resolves to the asset directly. Same change as was made to the README install snippets in #308.

## Testing

Ran the resulting script on darwin/arm64: it downloads the `arm64` asset (`Mach-O 64-bit executable arm64`), `shuttle version` prints `0.25.0`, and `GITHUB_PATH` receives a fully expanded path.

## Note

There is a similar install snippet in a "Shuttle prepare" composite action in another repo that has the same hardcoded `Linux-*) shuttle-linux-amd64` case and the same redirect scraping. It is outside this repo so it is not covered here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk CI install script fixes with no application runtime, auth, or data-handling changes; main risk is mis-detection on exotic runners, which now fails explicitly.
> 
> **Overview**
> **Install Shuttle** composite action (`action.yml`) is refactored so Linux runners get the right CPU binary and later workflow steps can find `shuttle` on macOS.
> 
> **Linux arm64:** The script no longer always downloads `shuttle-linux-amd64`. It maps `uname -m` to `arm64` or `amd64` (and fails on unknown arch) and `uname -s` to `darwin` or `linux`, then fetches `shuttle-$os-$arch`.
> 
> **Download:** Release version is no longer resolved by scraping the `releases/latest` redirect; it uses `releases/latest/download/shuttle-$os-$arch`, aligned with README install snippets.
> 
> **macOS PATH:** `GITHUB_PATH` is updated with `$HOME/bin` instead of the literal `~/bin/`, so GitHub Actions expands the entry for subsequent steps (the in-step `export PATH` had masked the bug for `shuttle version` only).
> 
> Install layout is unchanged in spirit: Darwin installs to `$HOME/bin` and adds it to `GITHUB_PATH`; Linux moves the binary to `/usr/local/bin/shuttle`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52a17f08b03e8ae5aded5e1089b4098e22d7fe72. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->